### PR TITLE
Convert search regex to Option type [Closes #59]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ clippers = "0.1.2"
 regex = "1.9.5"
 serde_yaml = "0.9.25"
 chrono = "0.4.31"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
Using [cargo-flamegraph](https://github.com/killercup/cargo-flamegraph) against the release build I was able to create an initial profile of the application

After analyzing the resultant graphs, I noticed that we re-compile the default search Regex string on every render. This is a costly [anti-pattern](https://docs.rs/regex/latest/regex/#avoid-re-compiling-regexes-especially-in-a-loop). I converted the Regex used for search filtering to an `Option` type which prevents extra Regex compilation until a search query is actually entered by a user

Flamegraph against current `main` showing the recurring regex build stacks:
![flamegraph-main](https://github.com/FormidableLabs/cli-network-viewer/assets/5840711/31661c59-24f7-40dd-9c95-c6d197ff8892)

Flamegraph after changes in this PR; the regex build steps have been removed:
![flamegraph-regex-compile](https://github.com/FormidableLabs/cli-network-viewer/assets/5840711/8daed0f1-49d0-46d5-879d-6744e560527a)

