### PR TITLE
Add details pane with horizontal tabs and network timing chart [Closes #64 and #45]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ regex = "1.9.5"
 serde_yaml = "0.9.25"
 pretty_assertions = "1.4.0"
 chrono = "0.4.31"
+strum = "0.25.0"
+strum_macros = "0.25.3"
 
 [profile.release]
 debug = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use crate::services::websocket::{Client, Trace};
 use crate::tui::{Event, Tui};
 use crate::wss::client;
 
-#[derive(Clone, Copy, Default, Debug, PartialEq, EnumIter)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, EnumIter)]
 #[repr(u8)]
 pub enum DetailsPane {
     #[default]
@@ -55,17 +55,15 @@ impl Display for FilterScreen {
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ActiveBlock {
     #[default]
-    TracesBlock,
-    RequestDetails,
+    Traces,
+    Details,
     RequestBody,
-    ResponseDetails,
     ResponseBody,
-    RequestSummary,
-    SearchQuery,
     Help,
     Debug,
     Filter(FilterScreen),
     Sort,
+    SearchQuery,
 }
 
 #[derive(Default, Clone)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,16 +18,14 @@ use crate::tui::{Event, Tui};
 use crate::wss::client;
 
 #[derive(Clone, Copy, Default, PartialEq, Debug)]
-pub enum RequestDetailsPane {
-    Query,
+pub enum DetailsPane {
     #[default]
-    Headers,
-}
-
-#[derive(Clone, Copy, Default, PartialEq, Debug)]
-pub enum ResponseDetailsPane {
-    #[default]
-    Body,
+    RequestDetails,
+    RequestHeaders,
+    QueryParams,
+    ResponseDetails,
+    ResponseHeaders,
+    Timing,
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Debug)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crossterm::event::KeyEvent;
 use ratatui::widgets::ScrollbarState;
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Mutex;
@@ -17,12 +18,13 @@ use crate::services::websocket::{Client, Trace};
 use crate::tui::{Event, Tui};
 use crate::wss::client;
 
-#[derive(Clone, Copy, Default, PartialEq, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, EnumIter)]
+#[repr(u8)]
 pub enum DetailsPane {
     #[default]
-    RequestDetails,
-    RequestHeaders,
+    RequestDetails = 0,
     QueryParams,
+    RequestHeaders,
     ResponseDetails,
     ResponseHeaders,
     Timing,

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -398,11 +398,13 @@ pub fn handle_down(
 
                 let params = parse_query_params(item.http.clone().unwrap_or_default().uri);
 
-                if app.selected_params_index + 1 >= params.len() {
+                let next_index = if app.selected_params_index + 1 >= params.len() {
                     params.len() - 1
                 } else {
                     app.selected_params_index + 1
                 };
+
+                app.selected_params_index = next_index;
 
                 None
             }

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{Action, ActiveBlock, FilterScreen, DetailsPane};
+use crate::app::{Action, ActiveBlock, DetailsPane, FilterScreen};
 use crate::components::home::Home;
 use crate::consts::{
     NETWORK_REQUESTS_UNUSABLE_VERTICAL_SPACE, REQUEST_HEADERS_UNUSABLE_VERTICAL_SPACE,
@@ -15,6 +15,7 @@ use crossterm::event::{KeyEvent, KeyModifiers};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::time::Duration;
+use strum::IntoEnumIterator;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::sleep;
 
@@ -588,28 +589,30 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
 }
 
 pub fn handle_pane_next(app: &mut Home) -> Option<Action> {
-    match (app.active_block, app.details_block) {
-        (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
-            app.details_block = DetailsPane::QueryParams
-        }
-        (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
-            app.details_block = DetailsPane::RequestHeaders
-        }
-        (_, _) => {}
+    // cycle so the last pane advances to the first
+    let mut iter = DetailsPane::iter().cycle();
+
+    // advance iterator to the current block
+    iter.find(|&v| app.details_block == v);
+
+    // set current to the next item
+    if let Some(next_pane) = iter.next() {
+        app.details_block = next_pane;
     }
 
     None
 }
 
 pub fn handle_pane_prev(app: &mut Home) -> Option<Action> {
-    match (app.active_block, app.details_block) {
-        (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
-            app.details_block = DetailsPane::QueryParams
-        }
-        (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
-            app.details_block = DetailsPane::RequestHeaders
-        }
-        (_, _) => {}
+    // cycle so the last pane advances to the first
+    let mut iter = DetailsPane::iter().rev().cycle();
+
+    // advance iterator to the current block
+    iter.find(|&v| app.details_block == v);
+
+    // set current to the next item
+    if let Some(next_pane) = iter.next() {
+        app.details_block = next_pane;
     }
 
     None

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -574,13 +574,13 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
         ActiveBlock::ResponseBody => ActiveBlock::Details,
         _ => app.active_block,
     };
-        if next_block != app.active_block {
-            app.active_block = next_block;
+    if next_block != app.active_block {
+        app.active_block = next_block;
 
-            Some(Action::ActivateBlock(next_block))
-        } else {
-            None
-        }
+        Some(Action::ActivateBlock(next_block))
+    } else {
+        None
+    }
 }
 
 pub fn handle_pane_next(app: &mut Home) -> Option<Action> {

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -1,4 +1,4 @@
-use crate::app::{Action, ActiveBlock, FilterScreen, RequestDetailsPane};
+use crate::app::{Action, ActiveBlock, FilterScreen, DetailsPane};
 use crate::components::home::Home;
 use crate::consts::{
     NETWORK_REQUESTS_UNUSABLE_VERTICAL_SPACE, REQUEST_HEADERS_UNUSABLE_VERTICAL_SPACE,
@@ -104,7 +104,7 @@ pub fn handle_up(
             }
             _ => None,
         },
-        _ => match (app.active_block, app.request_details_block) {
+        _ => match (app.active_block, app.details_block) {
             (ActiveBlock::Filter(_), _) => match app.filter_index.checked_sub(1) {
                 Some(v) => {
                     app.filter_index = v;
@@ -161,7 +161,7 @@ pub fn handle_up(
                     Some(Action::SelectTrace(get_currently_selected_trace(app)))
                 }
             }
-            (ActiveBlock::RequestDetails, RequestDetailsPane::Query) => {
+            (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
                 let next_index = if app.selected_params_index == 0 {
                     0
                 } else {
@@ -172,7 +172,7 @@ pub fn handle_up(
 
                 None
             }
-            (ActiveBlock::RequestDetails, RequestDetailsPane::Headers) => {
+            (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
                 let next_index = if app.selected_request_header_index == 0 {
                     0
                 } else {
@@ -308,7 +308,7 @@ pub fn handle_down(
             }
             _ => None,
         },
-        _ => match (app.active_block, app.request_details_block) {
+        _ => match (app.active_block, app.details_block) {
             (ActiveBlock::Filter(FilterScreen::FilterMethod), _) => {
                 if app.filter_index + 1 < app.method_filters.len() {
                     app.filter_index += 1;
@@ -392,7 +392,7 @@ pub fn handle_down(
 
                 Some(Action::SelectTrace(get_currently_selected_trace(app)))
             }
-            (ActiveBlock::RequestDetails, RequestDetailsPane::Query) => {
+            (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
                 let item = app.selected_trace.as_ref().unwrap();
 
                 let params = parse_query_params(item.http.clone().unwrap_or_default().uri);
@@ -405,7 +405,7 @@ pub fn handle_down(
 
                 None
             }
-            (ActiveBlock::RequestDetails, RequestDetailsPane::Headers) => {
+            (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
                 let item = app.selected_trace.as_ref().unwrap();
 
                 let item_length = item.http.clone().unwrap_or_default().request_headers.len();
@@ -588,12 +588,12 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
 }
 
 pub fn handle_pane_next(app: &mut Home) -> Option<Action> {
-    match (app.active_block, app.request_details_block) {
-        (ActiveBlock::RequestDetails, RequestDetailsPane::Headers) => {
-            app.request_details_block = RequestDetailsPane::Query
+    match (app.active_block, app.details_block) {
+        (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
+            app.details_block = DetailsPane::QueryParams
         }
-        (ActiveBlock::RequestDetails, RequestDetailsPane::Query) => {
-            app.request_details_block = RequestDetailsPane::Headers
+        (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
+            app.details_block = DetailsPane::RequestHeaders
         }
         (_, _) => {}
     }
@@ -602,12 +602,12 @@ pub fn handle_pane_next(app: &mut Home) -> Option<Action> {
 }
 
 pub fn handle_pane_prev(app: &mut Home) -> Option<Action> {
-    match (app.active_block, app.request_details_block) {
-        (ActiveBlock::RequestDetails, RequestDetailsPane::Headers) => {
-            app.request_details_block = RequestDetailsPane::Query
+    match (app.active_block, app.details_block) {
+        (ActiveBlock::RequestDetails, DetailsPane::RequestHeaders) => {
+            app.details_block = DetailsPane::QueryParams
         }
-        (ActiveBlock::RequestDetails, RequestDetailsPane::Query) => {
-            app.request_details_block = RequestDetailsPane::Headers
+        (ActiveBlock::RequestDetails, DetailsPane::QueryParams) => {
+            app.details_block = DetailsPane::RequestHeaders
         }
         (_, _) => {}
     }

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -419,7 +419,7 @@ impl Component for Home {
 
                     render::render_traces(self, frame, left_column);
 
-                    render::render_request_details(self, frame, right_column_layout[0]);
+                    render::details(self, frame, right_column_layout[0]);
                     self.request_json_viewer.render(frame, body_layout[1])?;
                     self.response_json_viewer.render(frame, body_layout[0])?;
 
@@ -468,14 +468,14 @@ impl Component for Home {
                         )
                         .split(main_layout[3]);
 
-                    render::render_request_details(self, frame, request_layout[0]);
+                    render::details(self, frame, request_layout[0]);
                     self.request_json_viewer.render(frame, request_layout[1])?;
                     self.response_json_viewer
                         .render(frame, response_layout[1])?;
                     render::render_traces(self, frame, main_layout[0]);
 
-                    render::render_request_summary(self, frame, main_layout[1]);
-                    render::render_response_details(self, frame, response_layout[0]);
+                    // render::render_request_summary(self, frame, main_layout[1]);
+                    // render::render_response_details(self, frame, response_layout[0]);
 
                     render::render_search(self, frame);
                     render::render_footer(self, frame, main_layout[4]);

--- a/src/components/jsonviewer.rs
+++ b/src/components/jsonviewer.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use ratatui::prelude::{
-    Alignment, Color, Constraint, Direction, Layout, Line, Margin, Modifier, Rect, Span, Style,
+    Alignment, Constraint, Direction, Layout, Line, Margin, Modifier, Rect, Span, Style,
 };
 use ratatui::widgets::{
     block::Padding, Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,13 +12,13 @@ use crate::services::websocket::{HTTPTrace, State, Trace};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HTTPTimings {
-    blocked: f32,
-    dns: f32,
-    connect: f32,
-    send: f32,
-    wait: f32,
-    receive: f32,
-    ssl: f32,
+    pub blocked: f32,
+    pub dns: f32,
+    pub connect: f32,
+    pub send: f32,
+    pub wait: f32,
+    pub receive: f32,
+    pub ssl: f32,
 }
 
 pub fn populate_header_map(raw_headers: &Map<String, Value>, map: &mut HeaderMap) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,8 +10,8 @@ use regex::Regex;
 
 use crate::services::websocket::{HTTPTrace, State, Trace};
 
-#[derive(Serialize, Deserialize, Debug)]
-struct HTTPTimings {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HTTPTimings {
     blocked: f32,
     dns: f32,
     connect: f32,
@@ -101,8 +101,8 @@ pub fn parse_raw_trace(stringified_json: &str) -> Result<Payload, Box<dyn std::e
             let timestamp = &data["timestamp"];
 
             let timestamp = match timestamp {
-                Value::String(v) => u64::from_str(v.as_str()).map_err(|_| "".to_string()),
-                Value::Number(v) => Ok(v.as_u64().unwrap()),
+                Value::String(v) => i64::from_str(v.as_str()).map_err(|_| "".to_string()),
+                Value::Number(v) => Ok(v.as_i64().unwrap()),
                 _ => Err("Must be a number.".to_string()),
             }
             .ok()
@@ -207,21 +207,18 @@ pub fn parse_raw_trace(stringified_json: &str) -> Result<Payload, Box<dyn std::e
                     .ok()
                     .expect("Url is mandatory");
 
-                    let port = &http["port"];
+                    let port = http["port"].to_string();
 
-                    let port = match port {
-                        Value::String(k) => Ok(k.to_string()),
-                        _ => Err("".to_string()),
-                    }
-                    .ok();
+                    let path = http["path"].to_string();
 
-                    let timinggs = match http.get("timings") {
+                    let timings = match http.get("timings") {
                         Some(d) => serde_json::from_value::<HTTPTimings>(d.clone()).ok(),
                         _ => None,
                     };
 
                     let mut http_trace = HTTPTrace {
                         port,
+                        path,
                         duration,
                         uri,
                         response_headers: http::HeaderMap::new(),
@@ -236,6 +233,7 @@ pub fn parse_raw_trace(stringified_json: &str) -> Result<Payload, Box<dyn std::e
                         pretty_request_body: None,
                         pretty_request_body_lines: None,
                         state,
+                        timings,
                         raw: pretty_parse_body(stringified_json)?,
                     };
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,14 +9,13 @@ use ratatui::prelude::{Alignment, Constraint, Direction, Layout, Margin, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::{
     buffer::Buffer,
-    style::{Modifier, Style, Stylize},
+    style::{Modifier, Style},
     symbols,
     symbols::border,
     widgets::{
         block::{Position, Title},
-        Axis, Bar, BarChart, BarGroup, Block, BorderType, Borders, Cell, Chart, Clear, Dataset,
-        GraphType, List, ListItem, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
-        Tabs, Widget,
+        Axis, Block, BorderType, Borders, Cell, Chart, Clear, Dataset, GraphType, List, ListItem,
+        Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table, Tabs, Widget,
     },
     Frame,
 };
@@ -154,16 +153,16 @@ fn render_headers(app: &Home, frame: &mut Frame, area: Rect, header_type: Header
 
                     Row::new(vec![String::from(header_name), String::from(header_value)]).style(
                         match (is_active_header, active_block, header_type) {
-                            (true, ActiveBlock::RequestDetails, HeaderType::Request) => {
+                            (true, ActiveBlock::Details, HeaderType::Request) => {
                                 get_row_style(RowStyle::Selected, app.colors.clone())
                             }
-                            (true, ActiveBlock::ResponseDetails, HeaderType::Response) => {
+                            (true, ActiveBlock::Details, HeaderType::Response) => {
                                 get_row_style(RowStyle::Selected, app.colors.clone())
                             }
-                            (false, ActiveBlock::RequestDetails, HeaderType::Request) => {
+                            (false, ActiveBlock::Details, HeaderType::Request) => {
                                 get_row_style(RowStyle::Active, app.colors.clone())
                             }
-                            (false, ActiveBlock::ResponseDetails, HeaderType::Response) => {
+                            (false, ActiveBlock::Details, HeaderType::Response) => {
                                 get_row_style(RowStyle::Active, app.colors.clone())
                             }
                             (true, _, _) => get_row_style(RowStyle::Inactive, app.colors.clone()),
@@ -208,7 +207,7 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
             Block::default()
                 .borders(Borders::BOTTOM)
                 .border_style(
-                    Style::default().fg(if active_block == ActiveBlock::RequestDetails {
+                    Style::default().fg(if active_block == ActiveBlock::Details {
                         app.colors.surface.selected
                     } else {
                         app.colors.surface.unselected
@@ -243,7 +242,7 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
                 .alignment(Alignment::Right),
             )
             .border_style(get_border_style(
-                app.active_block == ActiveBlock::RequestDetails,
+                app.active_block == ActiveBlock::Details,
                 app.colors.clone(),
             ))
             .border_type(BorderType::Plain)
@@ -318,10 +317,10 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
 
                         Row::new(vec![cloned_name, cloned_value]).style(
                             match (is_selected, active_block) {
-                                (true, ActiveBlock::RequestDetails) => {
+                                (true, ActiveBlock::Details) => {
                                     get_row_style(RowStyle::Selected, app.colors.clone())
                                 }
-                                (false, ActiveBlock::RequestDetails) => {
+                                (false, ActiveBlock::Details) => {
                                     get_row_style(RowStyle::Active, app.colors.clone())
                                 }
                                 (true, _) => get_row_style(RowStyle::Inactive, app.colors.clone()),
@@ -616,12 +615,10 @@ pub fn render_traces(app: &Home, frame: &mut Frame, area: Rect) {
                 .clone();
 
             Row::new(str_vec).style(match (*selected, active_block) {
-                (true, ActiveBlock::TracesBlock) => {
+                (true, ActiveBlock::Traces) => {
                     get_row_style(RowStyle::Selected, app.colors.clone())
                 }
-                (false, ActiveBlock::TracesBlock) => {
-                    get_row_style(RowStyle::Active, app.colors.clone())
-                }
+                (false, ActiveBlock::Traces) => get_row_style(RowStyle::Active, app.colors.clone()),
                 (true, _) => get_row_style(RowStyle::Inactive, app.colors.clone()),
                 (false, _) => get_row_style(RowStyle::Default, app.colors.clone()),
             })
@@ -641,7 +638,7 @@ pub fn render_traces(app: &Home, frame: &mut Frame, area: Rect) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(get_border_style(
-                    app.active_block == ActiveBlock::TracesBlock,
+                    app.active_block == ActiveBlock::Traces,
                     app.colors.clone(),
                 ))
                 .title(title)

--- a/src/render.rs
+++ b/src/render.rs
@@ -15,7 +15,7 @@ use ratatui::widgets::{
 };
 use ratatui::Frame;
 
-use crate::app::{Action, ActiveBlock, RequestDetailsPane};
+use crate::app::{Action, ActiveBlock, DetailsPane};
 use crate::components::home::{FilterSource, Home};
 use crate::config::Colors;
 use crate::consts::{
@@ -255,24 +255,35 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                 //
                 .highlight_symbol(">>");
 
-            let tabs = Tabs::new(vec!["Request Header", "Request Params"])
-                .block(
-                    Block::default()
-                        .borders(Borders::BOTTOM)
-                        .style(Style::default().fg(
-                            if active_block == ActiveBlock::RequestDetails {
-                                app.colors.surface.selected
-                            } else {
-                                app.colors.surface.unselected
-                            },
-                        ))
-                        .border_type(BorderType::Plain),
-                )
-                .select(match app.request_details_block {
-                    RequestDetailsPane::Headers => 0,
-                    RequestDetailsPane::Query => 1,
-                })
-                .highlight_style(Style::default().fg(app.colors.surface.selected));
+            let tabs = Tabs::new(vec![
+                "REQUEST DETAILS",
+                "QUERY PARAMS",
+                "REQUEST HEADERS",
+                "RESPONSE DETAILS",
+                "RESPONSE HEADERS",
+                "TIMING",
+            ])
+            .block(
+                Block::default()
+                    .borders(Borders::BOTTOM)
+                    .border_style(Style::default().fg(
+                        if active_block == ActiveBlock::RequestDetails {
+                            app.colors.surface.selected
+                        } else {
+                            app.colors.surface.unselected
+                        },
+                    ))
+                    .border_type(BorderType::Plain),
+            )
+            .select(match app.details_block {
+                DetailsPane::RequestDetails => 0,
+                DetailsPane::QueryParams => 1,
+                DetailsPane::RequestHeaders => 2,
+                DetailsPane::ResponseDetails => 3,
+                DetailsPane::ResponseHeaders => 4,
+                DetailsPane::Timing => 5,
+            })
+            .highlight_style(Style::default().fg(app.colors.surface.selected));
 
             let inner_layout = Layout::default()
                 .direction(Direction::Vertical)
@@ -306,11 +317,14 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
             frame.render_widget(main, area);
             frame.render_widget(tabs, inner_layout[0]);
 
-            match app.request_details_block {
-                RequestDetailsPane::Query => {
+            match app.details_block {
+                DetailsPane::RequestDetails => {
                     frame.render_widget(table, inner_layout[1]);
                 }
-                RequestDetailsPane::Headers => {
+                DetailsPane::QueryParams => {
+                    frame.render_widget(table, inner_layout[1]);
+                }
+                DetailsPane::RequestHeaders => {
                     render_headers(app, frame, inner_layout[1], HeaderType::Request);
 
                     let vertical_scroll = Scrollbar::new(ScrollbarOrientation::VerticalRight);
@@ -340,6 +354,15 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                             &mut app.request_details.scroll_state.clone(),
                         );
                     }
+                }
+                DetailsPane::ResponseDetails => {
+                    frame.render_widget(table, inner_layout[1]);
+                }
+                DetailsPane::ResponseHeaders => {
+                    frame.render_widget(table, inner_layout[1]);
+                }
+                DetailsPane::Timing => {
+                    frame.render_widget(table, inner_layout[1]);
                 }
             }
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -179,11 +179,6 @@ fn render_headers(app: &Home, frame: &mut Frame, area: Rect, header_type: Header
 
     let table = Table::new(rows)
         .style(Style::default().fg(app.colors.text.default))
-        .header(
-            Row::new(vec!["Header name", "Header value"])
-                .style(Style::default().fg(app.colors.text.accent_1))
-                .bottom_margin(1),
-        )
         .widths(&[Constraint::Percentage(40), Constraint::Percentage(60)])
         .highlight_style(Style::default().add_modifier(Modifier::BOLD))
         .highlight_symbol(">>");
@@ -217,11 +212,25 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
                 .border_set(border::DOUBLE),
         )
         .select(app.details_block as usize)
-        .highlight_style(Style::default().fg(app.colors.surface.selected));
+        .style(
+            Style::default().fg(if active_block == ActiveBlock::Details {
+                app.colors.text.accent_1
+            } else {
+                app.colors.text.unselected
+            }),
+        )
+        .highlight_style(
+            Style::default().fg(if active_block == ActiveBlock::Details {
+                app.colors.text.accent_2
+            } else {
+                app.colors.text.unselected
+            }),
+        );
 
         let inner_layout = Layout::default()
+            .vertical_margin(2)
+            .horizontal_margin(3)
             .direction(Direction::Vertical)
-            .margin(1)
             .constraints([Constraint::Max(2), Constraint::Min(1)].as_ref())
             .split(area);
 
@@ -308,21 +317,16 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
 
                 let rows = raw_params
                     .iter()
-                    .map(|param| {
-                        let (name, value) = param;
-                        let cloned_name = name.deref().clone();
-                        let cloned_value = value.deref().clone();
-
+                    .map(|(name, value)| {
                         let is_selected = match current_param_selected {
                             Some(v) => {
                                 let (current_name, _) = v;
-
                                 current_name.deref() == name
                             }
                             None => false,
                         };
 
-                        Row::new(vec![cloned_name, cloned_value]).style(
+                        Row::new(vec![name.to_string(), value.to_string()]).style(
                             match (is_selected, active_block) {
                                 (true, ActiveBlock::Details) => {
                                     get_row_style(RowStyle::Selected, app.colors.clone())
@@ -338,19 +342,17 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
                     .collect::<Vec<Row>>();
 
                 let table = Table::new(rows)
-                    .style(Style::default().fg(app.colors.text.unselected))
-                    .header(
-                        Row::new(vec!["Query name", "Query Param value"])
-                            .style(Style::default().fg(app.colors.text.accent_1))
-                            .bottom_margin(1),
+                    .style(
+                        Style::default().fg(if active_block == ActiveBlock::Details {
+                            app.colors.text.accent_1
+                        } else {
+                            app.colors.text.unselected
+                        }),
                     )
-                    .widths(&[
-                        Constraint::Percentage(10),
-                        Constraint::Percentage(70),
-                        Constraint::Length(20),
-                    ])
+                    .widths(&[Constraint::Percentage(40), Constraint::Percentage(60)])
                     .highlight_style(Style::default().add_modifier(Modifier::BOLD))
                     .highlight_symbol(">>");
+
                 frame.render_widget(table, inner_layout[1]);
             }
             DetailsPane::RequestHeaders => {

--- a/src/render.rs
+++ b/src/render.rs
@@ -432,8 +432,6 @@ fn render_horizontal_barchart(
     if let Some(trace) = maybe_trace {
         if let Some(http) = &trace.http {
             if let Some(timings) = &http.timings {
-                let bg = colors.surface.null;
-
                 let timings_vec: Vec<f64> = vec![
                     timings.blocked.into(),
                     timings.dns.into(),
@@ -443,23 +441,15 @@ fn render_horizontal_barchart(
                     timings.wait.into(),
                     timings.receive.into(),
                 ];
-
                 let total = timings_vec.clone().into_iter().fold(0.0, |a, b| a + b);
-
-                let x_axis = Axis::default()
-                    .style(Style::default().white())
-                    .bounds([0.0, total]);
-
-                let y_axis = Axis::default()
-                    .style(Style::default().white())
-                    .bounds([0.0, 6.0]);
+                let x_axis = Axis::default().bounds([0.0, total]);
+                let y_axis = Axis::default().bounds([0.0, 6.0]);
 
                 Chart::new(vec![
                     Dataset::default()
                         .name("blocked")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (0.0, 6.0),
                             (timings_vec[0..1].iter().fold(0.0, |a, b| a + b), 6.0),
@@ -468,7 +458,6 @@ fn render_horizontal_barchart(
                         .name("DNS")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..1].iter().fold(0.0, |a, b| a + b), 5.0),
                             (timings_vec[0..2].iter().fold(0.0, |a, b| a + b), 5.0),
@@ -477,7 +466,6 @@ fn render_horizontal_barchart(
                         .name("connecting")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..2].iter().fold(0.0, |a, b| a + b), 4.0),
                             (timings_vec[0..3].iter().fold(0.0, |a, b| a + b), 4.0),
@@ -486,7 +474,6 @@ fn render_horizontal_barchart(
                         .name("TLS")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..3].iter().fold(0.0, |a, b| a + b), 3.0),
                             (timings_vec[0..4].iter().fold(0.0, |a, b| a + b), 3.0),
@@ -495,7 +482,6 @@ fn render_horizontal_barchart(
                         .name("sending")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..4].iter().fold(0.0, |a, b| a + b), 2.0),
                             (timings_vec[0..5].iter().fold(0.0, |a, b| a + b), 2.0),
@@ -504,7 +490,6 @@ fn render_horizontal_barchart(
                         .name("waiting")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..5].iter().fold(0.0, |a, b| a + b), 1.0),
                             (timings_vec[0..6].iter().fold(0.0, |a, b| a + b), 1.0),
@@ -513,13 +498,13 @@ fn render_horizontal_barchart(
                         .name("receiving")
                         .marker(symbols::Marker::Block)
                         .graph_type(GraphType::Line)
-                        .style(Style::default().fg(bg))
                         .data(&[
                             (timings_vec[0..6].iter().fold(0.0, |a, b| a + b), 0.0),
                             (timings_vec[0..7].iter().fold(0.0, |a, b| a + b), 0.0),
                         ]),
                 ])
-                .hidden_legend_constraints((Constraint::Length(0), Constraint::Ratio(1, 4)))
+                .style(Style::default().fg(colors.surface.null))
+                .hidden_legend_constraints((Constraint::Length(0), Constraint::Length(0)))
                 .x_axis(x_axis)
                 .y_axis(y_axis)
                 .render(area, buf);

--- a/src/render.rs
+++ b/src/render.rs
@@ -376,8 +376,34 @@ pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
                 frame.render_widget(table, inner_layout[1])
             }
             DetailsPane::ResponseHeaders => {
-                let table = Table::new([]);
-                frame.render_widget(table, inner_layout[1])
+                render_headers(app, frame, inner_layout[1], HeaderType::Response);
+
+                let vertical_scroll = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+
+                let content_length = if let Some(trace) = &app.selected_trace {
+                    trace
+                        .http
+                        .clone()
+                        .unwrap_or_default()
+                        .response_headers
+                        .len()
+                        .clone()
+                } else {
+                    0
+                };
+
+                let viewport_height = area.height - REQUEST_HEADERS_UNUSABLE_VERTICAL_SPACE as u16;
+
+                if content_length > viewport_height.into() {
+                    frame.render_stateful_widget(
+                        vertical_scroll,
+                        area.inner(&Margin {
+                            horizontal: 0,
+                            vertical: 2,
+                        }),
+                        &mut app.request_details.scroll_state.clone(),
+                    );
+                }
             }
             DetailsPane::Timing => {
                 let table = Table::new([]);

--- a/src/render.rs
+++ b/src/render.rs
@@ -275,14 +275,7 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                     ))
                     .border_type(BorderType::Plain),
             )
-            .select(match app.details_block {
-                DetailsPane::RequestDetails => 0,
-                DetailsPane::QueryParams => 1,
-                DetailsPane::RequestHeaders => 2,
-                DetailsPane::ResponseDetails => 3,
-                DetailsPane::ResponseHeaders => 4,
-                DetailsPane::Timing => 5,
-            })
+            .select(app.details_block as usize)
             .highlight_style(Style::default().fg(app.colors.surface.selected));
 
             let inner_layout = Layout::default()

--- a/src/render.rs
+++ b/src/render.rs
@@ -174,7 +174,7 @@ fn render_headers(app: &Home, frame: &mut Frame, area: Rect, header_type: Header
     frame.render_widget(table, area);
 }
 
-pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
+pub fn details(app: &Home, frame: &mut Frame, area: Rect) {
     let active_block = app.active_block;
 
     match &app.selected_trace {
@@ -185,75 +185,6 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                 .unwrap_or_default()
                 .uri
                 .clone();
-
-            let raw_params = parse_query_params(uri);
-
-            let mut cloned = raw_params;
-
-            cloned.sort_by(|a, b| {
-                let (name_a, _) = a;
-                let (name_b, _) = b;
-
-                name_a.cmp(name_b)
-            });
-
-            let current_param_selected = cloned.get(app.selected_params_index);
-
-            let rows = cloned
-                .iter()
-                .map(|param| {
-                    let (name, value) = param;
-                    let cloned_name = name.deref().clone();
-                    let cloned_value = value.deref().clone();
-
-                    let is_selected = match current_param_selected {
-                        Some(v) => {
-                            let (current_name, _) = v;
-
-                            current_name.deref() == name
-                        }
-                        None => false,
-                    };
-
-                    Row::new(vec![cloned_name, cloned_value]).style(
-                        match (is_selected, active_block) {
-                            (true, ActiveBlock::RequestDetails) => {
-                                get_row_style(RowStyle::Selected, app.colors.clone())
-                            }
-                            (false, ActiveBlock::RequestDetails) => {
-                                get_row_style(RowStyle::Active, app.colors.clone())
-                            }
-                            (true, _) => get_row_style(RowStyle::Inactive, app.colors.clone()),
-                            (false, _) => get_row_style(RowStyle::Default, app.colors.clone()),
-                        },
-                    )
-                })
-                .collect::<Vec<Row>>();
-
-            let table = Table::new(rows)
-                // You can set the style of the entire Table.
-                .style(Style::default().fg(app.colors.text.unselected))
-                // It has an optional header, which is simply a Row always visible at the top.
-                .header(
-                    Row::new(vec!["Query name", "Query Param value"])
-                        .style(Style::default().fg(app.colors.text.accent_1))
-                        // If you want some space between the header and the rest of the rows, you can always
-                        // specify some margin at the bottom.
-                        .bottom_margin(1),
-                )
-                .widths(&[
-                    Constraint::Percentage(10),
-                    Constraint::Percentage(70),
-                    Constraint::Length(20),
-                ])
-                // ...and they can be separated by a fixed spacing.
-                // .column_spacing(1)
-                // If you wish to highlight a row in any specific way when it is selected...
-                .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-                // ...and potentially show a symbol in front of the selection.
-                //
-                //
-                .highlight_symbol(">>");
 
             let tabs = Tabs::new(vec![
                 "REQUEST DETAILS",
@@ -285,10 +216,10 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                 .split(area);
 
             let main = Block::default()
-                .title("Request details")
+                .title("  DETAILS  ")
                 .title(
                     Title::from(format!(
-                        "{} of {}",
+                        "  {} OF {}  ",
                         app.selected_request_header_index + 1,
                         maybe_selected_item
                             .http
@@ -312,9 +243,105 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
 
             match app.details_block {
                 DetailsPane::RequestDetails => {
+                    let table = Table::new([])
+                        // You can set the style of the entire Table.
+                        .style(Style::default().fg(app.colors.text.unselected))
+                        // It has an optional header, which is simply a Row always visible at the top.
+                        .header(
+                            Row::new(vec!["Query name", "Query Param value"])
+                                .style(Style::default().fg(app.colors.text.accent_1))
+                                // If you want some space between the header and the rest of the rows, you can always
+                                // specify some margin at the bottom.
+                                .bottom_margin(1),
+                        )
+                        .widths(&[
+                            Constraint::Percentage(10),
+                            Constraint::Percentage(70),
+                            Constraint::Length(20),
+                        ])
+                        // ...and they can be separated by a fixed spacing.
+                        // .column_spacing(1)
+                        // If you wish to highlight a row in any specific way when it is selected...
+                        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+                        // ...and potentially show a symbol in front of the selection.
+                        //
+                        //
+                        .highlight_symbol(">>");
                     frame.render_widget(table, inner_layout[1]);
                 }
                 DetailsPane::QueryParams => {
+                    let raw_params = parse_query_params(uri);
+
+                    let mut cloned = raw_params;
+
+                    cloned.sort_by(|a, b| {
+                        let (name_a, _) = a;
+                        let (name_b, _) = b;
+
+                        name_a.cmp(name_b)
+                    });
+
+                    let current_param_selected = cloned.get(app.selected_params_index);
+
+                    let rows = cloned
+                        .iter()
+                        .map(|param| {
+                            let (name, value) = param;
+                            let cloned_name = name.deref().clone();
+                            let cloned_value = value.deref().clone();
+
+                            let is_selected = match current_param_selected {
+                                Some(v) => {
+                                    let (current_name, _) = v;
+
+                                    current_name.deref() == name
+                                }
+                                None => false,
+                            };
+
+                            Row::new(vec![cloned_name, cloned_value]).style(
+                                match (is_selected, active_block) {
+                                    (true, ActiveBlock::RequestDetails) => {
+                                        get_row_style(RowStyle::Selected, app.colors.clone())
+                                    }
+                                    (false, ActiveBlock::RequestDetails) => {
+                                        get_row_style(RowStyle::Active, app.colors.clone())
+                                    }
+                                    (true, _) => {
+                                        get_row_style(RowStyle::Inactive, app.colors.clone())
+                                    }
+                                    (false, _) => {
+                                        get_row_style(RowStyle::Default, app.colors.clone())
+                                    }
+                                },
+                            )
+                        })
+                        .collect::<Vec<Row>>();
+
+                    let table = Table::new(rows)
+                        // You can set the style of the entire Table.
+                        .style(Style::default().fg(app.colors.text.unselected))
+                        // It has an optional header, which is simply a Row always visible at the top.
+                        .header(
+                            Row::new(vec!["Query name", "Query Param value"])
+                                .style(Style::default().fg(app.colors.text.accent_1))
+                                // If you want some space between the header and the rest of the rows, you can always
+                                // specify some margin at the bottom.
+                                .bottom_margin(1),
+                        )
+                        .widths(&[
+                            Constraint::Percentage(10),
+                            Constraint::Percentage(70),
+                            Constraint::Length(20),
+                        ])
+                        // ...and they can be separated by a fixed spacing.
+                        // .column_spacing(1)
+                        // If you wish to highlight a row in any specific way when it is selected...
+                        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+                        // ...and potentially show a symbol in front of the selection.
+                        //
+                        //
+                        .highlight_symbol(">>");
                     frame.render_widget(table, inner_layout[1]);
                 }
                 DetailsPane::RequestHeaders => {
@@ -349,132 +376,21 @@ pub fn render_request_details(app: &Home, frame: &mut Frame, area: Rect) {
                     }
                 }
                 DetailsPane::ResponseDetails => {
-                    frame.render_widget(table, inner_layout[1]);
+                    let table = Table::new([]);
+                    frame.render_widget(table, inner_layout[1])
                 }
                 DetailsPane::ResponseHeaders => {
-                    frame.render_widget(table, inner_layout[1]);
+                    let table = Table::new([]);
+                    frame.render_widget(table, inner_layout[1])
                 }
                 DetailsPane::Timing => {
-                    frame.render_widget(table, inner_layout[1]);
+                    let table = Table::new([]);
+                    frame.render_widget(table, inner_layout[1])
                 }
             }
         }
         None => (),
     };
-}
-
-pub fn render_response_details(app: &Home, frame: &mut Frame, area: Rect) {
-    let items_as_vector = app.items.iter().collect::<Vec<&Trace>>();
-
-    let maybe_selected_item = items_as_vector.get(app.main.index);
-
-    let uri = match maybe_selected_item {
-        Some(item) => item.deref().http.clone().unwrap_or_default().uri,
-        None => String::from("Could not find request."),
-    };
-
-    let raw_params = parse_query_params(uri);
-
-    let is_progress = match &app.selected_trace {
-        Some(v) => v.http.clone().unwrap_or_default().duration.is_none(),
-        None => true,
-    };
-
-    if is_progress {
-        let status_bar = Paragraph::new("Loading...")
-            .style(Style::default().fg(app.colors.text.selected))
-            .alignment(Alignment::Center)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(get_border_style(
-                        app.active_block == ActiveBlock::ResponseDetails,
-                        app.colors.clone(),
-                    ))
-                    .title("Response details")
-                    .border_type(BorderType::Plain),
-            );
-
-        frame.render_widget(status_bar, area);
-    } else {
-        let mut cloned = raw_params;
-
-        cloned.sort_by(|a, b| {
-            let (name_a, _) = a;
-            let (name_b, _) = b;
-
-            name_a.cmp(name_b)
-        });
-
-        let inner_layout = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints([Constraint::Max(2), Constraint::Min(1)].as_ref())
-            .split(area);
-
-        let main = Block::default()
-            .title("Response details")
-            .title(
-                Title::from(format!(
-                    "{} of {}",
-                    app.selected_response_header_index + 1,
-                    app.selected_trace
-                        .clone()
-                        .unwrap_or_default()
-                        .http
-                        .unwrap_or_default()
-                        .response_headers
-                        .len()
-                ))
-                .position(Position::Bottom)
-                .alignment(Alignment::Right),
-            )
-            .border_style(get_border_style(
-                app.active_block == ActiveBlock::ResponseDetails,
-                app.colors.clone(),
-            ))
-            .border_type(BorderType::Plain)
-            .borders(Borders::ALL);
-
-        let tabs = Tabs::new(vec!["Response Header"])
-            .block(
-                Block::default()
-                    .borders(Borders::BOTTOM)
-                    .style(Style::default().fg(app.colors.text.unselected))
-                    .border_type(BorderType::Plain),
-            )
-            .select(0)
-            .highlight_style(Style::default().fg(app.colors.surface.selected));
-
-        frame.render_widget(main, area);
-        frame.render_widget(tabs, inner_layout[0]);
-
-        render_headers(app, frame, inner_layout[1], HeaderType::Response);
-
-        let vertical_scroll = Scrollbar::new(ScrollbarOrientation::VerticalRight);
-
-        let content_length = if let Some(trace) = &app.selected_trace {
-            trace
-                .http
-                .clone()
-                .unwrap_or_default()
-                .response_headers
-                .len()
-        } else {
-            0
-        };
-
-        if content_length > area.height as usize - RESPONSE_HEADERS_UNUSABLE_VERTICAL_SPACE {
-            frame.render_stateful_widget(
-                vertical_scroll,
-                area.inner(&Margin {
-                    horizontal: 0,
-                    vertical: 2,
-                }),
-                &mut app.response_details.scroll_state.clone(),
-            );
-        }
-    }
 }
 
 pub fn render_traces(app: &Home, frame: &mut Frame, area: Rect) {

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -1,5 +1,6 @@
 use crate::app::Action;
 use crate::mock;
+use crate::parser::HTTPTimings;
 use crate::parser::{parse_raw_trace, Payload};
 use crate::wss::WebSocket;
 use serde::{Deserialize, Serialize};
@@ -47,14 +48,16 @@ pub struct HTTPTrace {
     pub pretty_request_body_lines: Option<usize>,
     #[serde(skip_serializing, skip_deserializing)]
     pub http_version: Option<http::Version>,
+    pub timings: Option<HTTPTimings>,
+    pub port: String,
+    pub path: String,
     pub raw: String,
-    pub port: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Trace {
     pub id: String,
-    pub timestamp: u64,
+    pub timestamp: i64,
     pub service_name: Option<String>,
     pub http: Option<HTTPTrace>,
 }

--- a/src/wss.rs
+++ b/src/wss.rs
@@ -168,10 +168,8 @@ pub async fn client(
 
                                     let http_trace = trace.http.as_ref().unwrap();
 
-                                    if let Some(port) = &http_trace.port {
-                                        if port == "9999" {
-                                            should_persist = false;
-                                        }
+                                    if &http_trace.port == "9999" {
+                                        should_persist = false;
                                     }
 
                                     if let Some(s) = tx.clone() {


### PR DESCRIPTION
- Consolidates the request and response information under the tabs: request details, request query params, request headers, response details, response headers, and timing
- Adds request details fields
- Adds response details fields
- Adds the network timing chart under the timing tab