### PR TITLE
Filter and sort enhancements [Closes #66]

### DIFF
--- a/.config/config.yml
+++ b/.config/config.yml
@@ -20,14 +20,13 @@ mapping:
   ?: Help
   p: ToggleDebug
   d: DeleteItem
-  space: Select
   f: OpenFilter
   s: OpenSort
   "]": NextDetailsTab
   "[": PreviousDetailsTab
   e: ExpandAll
   E: CollapseAll
-  enter: ShowTraceDetails
+  enter: Select
 colors:
   surface:
     bg: !Indexed 235

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,8 +220,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
@@ -247,6 +256,20 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "convert_case"
@@ -571,9 +594,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -834,19 +857,21 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
+checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
 dependencies = [
  "bitflags 2.4.1",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools",
  "lru",
  "paste",
  "serde",
- "strum",
+ "stability",
+ "strum 0.26.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1041,12 +1066,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -1054,6 +1101,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 crossterm = { version = "0.27.0", features = ["event-stream", "serde"] }
 http = "0.2.9"
-ratatui = { version = "0.24.0", features = ["all-widgets", "serde"] }
+ratatui = { version = "0.26.1", features = ["all-widgets", "serde"] }
 serde = { version = "1.0.188" , features = ["derive"] }
 serde_json = { version = "1.0.107", features = ["preserve_order"] }
 futures-util = "0.3.28"

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,7 @@ pub enum FilterScreen {
     FilterMethod,
     FilterSource,
     FilterStatus,
+    FilterActions,
 }
 
 impl Display for FilterScreen {
@@ -118,6 +119,7 @@ pub enum Action {
     QuitApplication,
     NewSearch,
     UpdateSearchQuery(char),
+    UpdateFilter,
     UpdateSort,
     SelectSortSource(SortSource),
     SelectSortOrder(SortOrder),
@@ -157,14 +159,34 @@ pub enum Action {
     CloseDetailsPane(DetailsPane),
 }
 
-#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, strum_macros::Display, strum_macros::AsRefStr)]
+#[derive(
+    Default,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    strum_macros::Display,
+    strum_macros::AsRefStr,
+)]
 pub enum SortOrder {
     #[default]
     Ascending,
     Descending,
 }
 
-#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, strum_macros::Display, strum_macros::AsRefStr)]
+#[derive(
+    Default,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    strum_macros::Display,
+    strum_macros::AsRefStr,
+)]
 pub enum SortSource {
     #[default]
     Method,

--- a/src/app.rs
+++ b/src/app.rs
@@ -247,7 +247,6 @@ pub struct StatusFilter {
     Clone,
     Serialize,
     Deserialize,
-    strum_macros::Display,
     strum_macros::AsRefStr,
 )]
 pub enum SortDirection {
@@ -264,7 +263,6 @@ pub enum SortDirection {
     Clone,
     Serialize,
     Deserialize,
-    strum_macros::Display,
     strum_macros::AsRefStr,
 )]
 pub enum SortSource {
@@ -285,55 +283,29 @@ pub struct TraceSort {
 
 impl Display for TraceSort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.source, self.direction)
+    }
+}
+
+impl Display for SortDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TraceSort {
-                source: SortSource::Timestamp,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Timestamp ↑"),
-            TraceSort {
-                source: SortSource::Timestamp,
-                direction: SortDirection::Descending,
-            } => write!(f, "Timestamp ↓"),
-            TraceSort {
-                source: SortSource::Method,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Method ↑"),
-            TraceSort {
-                source: SortSource::Method,
-                direction: SortDirection::Descending,
-            } => write!(f, "Method ↓"),
-            TraceSort {
-                source: SortSource::Status,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Status ↑"),
-            TraceSort {
-                source: SortSource::Status,
-                direction: SortDirection::Descending,
-            } => write!(f, "Status ↓"),
-            TraceSort {
-                source: SortSource::Duration,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Duration ↑"),
-            TraceSort {
-                source: SortSource::Duration,
-                direction: SortDirection::Descending,
-            } => write!(f, "Duration ↓"),
-            TraceSort {
-                source: SortSource::Source,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Source ↑"),
-            TraceSort {
-                source: SortSource::Source,
-                direction: SortDirection::Descending,
-            } => write!(f, "Source ↓"),
-            TraceSort {
-                source: SortSource::Url,
-                direction: SortDirection::Ascending,
-            } => write!(f, "Url ↑"),
-            TraceSort {
-                source: SortSource::Url,
-                direction: SortDirection::Descending,
-            } => write!(f, "Url ↓"),
+            SortDirection::Ascending => write!(f, "↑"),
+            SortDirection::Descending => write!(f, "↓"),
+        }
+    }
+}
+
+impl Display for SortSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SortSource::Timestamp => write!(f, "Timestamp ↓"),
+            SortSource::Method => write!(f, "Method"),
+            SortSource::Status => write!(f, "Status"),
+            SortSource::Duration  => write!(f, "Duration"),
+            SortSource::Source =>write!(f, "Source"),
+            SortSource::Url => write!(f, "Url"),
+
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,13 @@ impl Display for FilterScreen {
     }
 }
 
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SortScreen {
+    #[default]
+    SortMain,
+    SortVariant,
+}
+
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ActiveBlock {
     #[default]
@@ -62,7 +69,7 @@ pub enum ActiveBlock {
     Help,
     Debug,
     Filter(FilterScreen),
-    Sort,
+    Sort(SortScreen),
     SearchQuery,
 }
 
@@ -133,6 +140,85 @@ pub enum Action {
     ExpandAll,
     CollapseAll,
     ActivateBlock(ActiveBlock),
+}
+
+#[derive(Default, PartialEq, Eq, Debug, Clone, strum_macros::Display)]
+pub enum SortOrder {
+    #[default]
+    Ascending,
+    Descending,
+}
+
+#[derive(Default, PartialEq, Eq, Debug, Clone, strum_macros::Display)]
+pub enum SortSource {
+    #[default]
+    Method,
+    Status,
+    Source,
+    Url,
+    Duration,
+    Timestamp,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
+pub struct TraceSort {
+    pub kind: SortSource,
+    pub order: SortOrder,
+}
+
+impl Display for TraceSort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TraceSort {
+                kind: SortSource::Timestamp,
+                order: SortOrder::Ascending,
+            } => write!(f, "Timestamp ↑"),
+            TraceSort {
+                kind: SortSource::Timestamp,
+                order: SortOrder::Descending,
+            } => write!(f, "Timestamp ↓"),
+            TraceSort {
+                kind: SortSource::Method,
+                order: SortOrder::Ascending,
+            } => write!(f, "Method ↑"),
+            TraceSort {
+                kind: SortSource::Method,
+                order: SortOrder::Descending,
+            } => write!(f, "Method ↓"),
+            TraceSort {
+                kind: SortSource::Status,
+                order: SortOrder::Ascending,
+            } => write!(f, "Status ↑"),
+            TraceSort {
+                kind: SortSource::Status,
+                order: SortOrder::Descending,
+            } => write!(f, "Status ↓"),
+            TraceSort {
+                kind: SortSource::Duration,
+                order: SortOrder::Ascending,
+            } => write!(f, "Duration ↑"),
+            TraceSort {
+                kind: SortSource::Duration,
+                order: SortOrder::Descending,
+            } => write!(f, "Duration ↓"),
+            TraceSort {
+                kind: SortSource::Source,
+                order: SortOrder::Ascending,
+            } => write!(f, "Source ↑"),
+            TraceSort {
+                kind: SortSource::Source,
+                order: SortOrder::Descending,
+            } => write!(f, "Source ↓"),
+            TraceSort {
+                kind: SortSource::Url,
+                order: SortOrder::Ascending,
+            } => write!(f, "Url ↑"),
+            TraceSort {
+                kind: SortSource::Url,
+                order: SortOrder::Descending,
+            } => write!(f, "Url ↓"),
+        }
+    }
 }
 
 #[derive(Default)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,9 @@ use crate::services::websocket::{Client, Trace};
 use crate::tui::{Event, Tui};
 use crate::wss::client;
 
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, Display, EnumIs, EnumIter)]
+#[derive(
+    Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, Display, EnumIs, EnumIter,
+)]
 #[repr(u8)]
 pub enum DetailsPane {
     #[default]
@@ -63,6 +65,7 @@ pub enum SortScreen {
     #[default]
     SortMain,
     SortVariant,
+    SortActions,
 }
 
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -115,6 +118,9 @@ pub enum Action {
     QuitApplication,
     NewSearch,
     UpdateSearchQuery(char),
+    UpdateSort,
+    SelectSortSource(SortSource),
+    SelectSortOrder(SortOrder),
     DeleteSearchQuery,
     ExitSearch,
     Help,
@@ -151,14 +157,14 @@ pub enum Action {
     CloseDetailsPane(DetailsPane),
 }
 
-#[derive(Default, PartialEq, Eq, Debug, Clone, strum_macros::Display)]
+#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, strum_macros::Display, strum_macros::AsRefStr)]
 pub enum SortOrder {
     #[default]
     Ascending,
     Descending,
 }
 
-#[derive(Default, PartialEq, Eq, Debug, Clone, strum_macros::Display)]
+#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize, strum_macros::Display, strum_macros::AsRefStr)]
 pub enum SortSource {
     #[default]
     Method,
@@ -171,7 +177,7 @@ pub enum SortSource {
 
 #[derive(PartialEq, Eq, Debug, Clone, Default)]
 pub struct TraceSort {
-    pub kind: SortSource,
+    pub source: SortSource,
     pub order: SortOrder,
 }
 
@@ -179,51 +185,51 @@ impl Display for TraceSort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TraceSort {
-                kind: SortSource::Timestamp,
+                source: SortSource::Timestamp,
                 order: SortOrder::Ascending,
             } => write!(f, "Timestamp ↑"),
             TraceSort {
-                kind: SortSource::Timestamp,
+                source: SortSource::Timestamp,
                 order: SortOrder::Descending,
             } => write!(f, "Timestamp ↓"),
             TraceSort {
-                kind: SortSource::Method,
+                source: SortSource::Method,
                 order: SortOrder::Ascending,
             } => write!(f, "Method ↑"),
             TraceSort {
-                kind: SortSource::Method,
+                source: SortSource::Method,
                 order: SortOrder::Descending,
             } => write!(f, "Method ↓"),
             TraceSort {
-                kind: SortSource::Status,
+                source: SortSource::Status,
                 order: SortOrder::Ascending,
             } => write!(f, "Status ↑"),
             TraceSort {
-                kind: SortSource::Status,
+                source: SortSource::Status,
                 order: SortOrder::Descending,
             } => write!(f, "Status ↓"),
             TraceSort {
-                kind: SortSource::Duration,
+                source: SortSource::Duration,
                 order: SortOrder::Ascending,
             } => write!(f, "Duration ↑"),
             TraceSort {
-                kind: SortSource::Duration,
+                source: SortSource::Duration,
                 order: SortOrder::Descending,
             } => write!(f, "Duration ↓"),
             TraceSort {
-                kind: SortSource::Source,
+                source: SortSource::Source,
                 order: SortOrder::Ascending,
             } => write!(f, "Source ↑"),
             TraceSort {
-                kind: SortSource::Source,
+                source: SortSource::Source,
                 order: SortOrder::Descending,
             } => write!(f, "Source ↓"),
             TraceSort {
-                kind: SortSource::Url,
+                source: SortSource::Url,
                 order: SortOrder::Ascending,
             } => write!(f, "Url ↑"),
             TraceSort {
-                kind: SortSource::Url,
+                source: SortSource::Url,
                 order: SortOrder::Descending,
             } => write!(f, "Url ↓"),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,7 +66,7 @@ impl Display for FilterScreen {
 pub enum SortScreen {
     #[default]
     Source,
-    Order,
+    Direction,
     Actions,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -251,8 +251,8 @@ pub struct StatusFilter {
     strum_macros::AsRefStr,
 )]
 pub enum SortDirection {
-    #[default]
     Ascending,
+    #[default]
     Descending,
 }
 
@@ -268,12 +268,12 @@ pub enum SortDirection {
     strum_macros::AsRefStr,
 )]
 pub enum SortSource {
-    #[default]
     Method,
     Status,
     Source,
     Url,
     Duration,
+    #[default]
     Timestamp,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -299,7 +299,7 @@ impl Display for SortDirection {
 impl Display for SortSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SortSource::Timestamp => write!(f, "Timestamp ↓"),
+            SortSource::Timestamp => write!(f, "Timestamp"),
             SortSource::Method => write!(f, "Method"),
             SortSource::Status => write!(f, "Status"),
             SortSource::Duration  => write!(f, "Duration"),

--- a/src/app.rs
+++ b/src/app.rs
@@ -121,6 +121,7 @@ pub enum Action {
     UpdateSearchQuery(char),
     UpdateFilter,
     UpdateSort,
+    SelectFilterScreen(FilterScreen),
     SelectSortSource(SortSource),
     SelectSortOrder(SortOrder),
     DeleteSearchQuery,

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -40,6 +40,21 @@ pub struct ActionableList {
 }
 
 impl ActionableList {
+    pub fn with_items(items: Vec<ActionableListItem>) -> Self {
+        Self {
+            items,
+            scroll_state: ListState::default(),
+            select_state: ListState::default(),
+        }
+    }
+
+    pub fn with_scroll_state(self, scroll_state: ListState) -> Self {
+        Self {
+            scroll_state,
+            ..self
+        }
+    }
+
     pub fn reset(&mut self) {
         self.scroll_state.select(None);
         self.select_state.select(None);

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -43,6 +43,10 @@ impl ActionableList {
         self.state.select(None);
     }
 
+    pub fn select(&mut self, index: usize) {
+        self.state.select(Some(index));
+    }
+
     pub fn next(&mut self) {
         let i = match self.state.selected() {
             Some(i) => {
@@ -71,7 +75,7 @@ impl ActionableList {
         self.state.select(Some(i));
     }
 
-    pub fn select(&mut self) -> Option<Action> {
+    pub fn action(&mut self) -> Option<Action> {
         match self.state.selected() {
             Some(i) => {
                 if let Some(item) = self.items.get(i) {

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -35,20 +35,26 @@ impl ActionableListItem {
 #[derive(Default, new)]
 pub struct ActionableList {
     pub items: Vec<ActionableListItem>,
-    pub state: ListState,
+    pub scroll_state: ListState,
+    pub select_state: ListState,
 }
 
 impl ActionableList {
     pub fn reset(&mut self) {
-        self.state.select(None);
+        self.scroll_state.select(None);
+        self.select_state.select(None);
+    }
+
+    pub fn top(&mut self, index: usize) {
+        self.scroll_state.select(Some(index));
     }
 
     pub fn select(&mut self, index: usize) {
-        self.state.select(Some(index));
+        self.select_state.select(Some(index));
     }
 
     pub fn next(&mut self) {
-        let i = match self.state.selected() {
+        let i = match self.scroll_state.selected() {
             Some(i) => {
                 if i >= self.items.len().saturating_sub(1) {
                     i
@@ -58,11 +64,11 @@ impl ActionableList {
             }
             None => 0,
         };
-        self.state.select(Some(i));
+        self.scroll_state.select(Some(i));
     }
 
     pub fn previous(&mut self) {
-        let i = match self.state.selected() {
+        let i = match self.scroll_state.selected() {
             Some(i) => {
                 if i == 0 {
                     i
@@ -72,11 +78,11 @@ impl ActionableList {
             }
             None => 0,
         };
-        self.state.select(Some(i));
+        self.scroll_state.select(Some(i));
     }
 
     pub fn action(&mut self) -> Option<Action> {
-        match self.state.selected() {
+        match self.scroll_state.selected() {
             Some(i) => {
                 if let Some(item) = self.items.get(i) {
                     item.action.clone()

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -40,7 +40,7 @@ pub struct ActionableList {
 
 impl ActionableList {
     pub fn reset(&mut self) {
-        self.state.select(Some(0));
+        self.state.select(None);
     }
 
     pub fn next(&mut self) {

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -24,11 +24,10 @@ impl ActionableListItem {
             action: None,
         }
     }
-    pub fn with_action(label: &str, value: &str, action: Action) -> Self {
+    pub fn with_action(self, action: Action) -> Self {
         Self {
-            label: label.to_string(),
-            value: Some(value.to_string()),
             action: Some(action),
+            ..self
         }
     }
 }

--- a/src/components/actionable_list.rs
+++ b/src/components/actionable_list.rs
@@ -37,6 +37,7 @@ pub struct ActionableList {
     pub items: Vec<ActionableListItem>,
     pub scroll_state: ListState,
     pub select_state: ListState,
+    pub show_select_labels: bool,
 }
 
 impl ActionableList {
@@ -45,12 +46,20 @@ impl ActionableList {
             items,
             scroll_state: ListState::default(),
             select_state: ListState::default(),
+            show_select_labels: false,
         }
     }
 
     pub fn with_scroll_state(self, scroll_state: ListState) -> Self {
         Self {
             scroll_state,
+            ..self
+        }
+    }
+
+    pub fn with_select_labels(self) -> Self {
+        Self {
+            show_select_labels: true,
             ..self
         }
     }

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -132,7 +132,7 @@ pub fn handle_up(
 
                 None
             }
-            (ActiveBlock::Sort(SortScreen::Order), _) => {
+            (ActiveBlock::Sort(SortScreen::Direction), _) => {
                 app.sort_directions.previous();
 
                 None
@@ -305,7 +305,7 @@ pub fn handle_down(
 
                 None
             }
-            (ActiveBlock::Sort(SortScreen::Order), _) => {
+            (ActiveBlock::Sort(SortScreen::Direction), _) => {
                 app.sort_directions.next();
 
                 None
@@ -404,12 +404,12 @@ pub fn handle_enter(app: &mut Home) -> Option<Action> {
         None
     } else if app.active_block == ActiveBlock::Details {
         match app.details_block {
-            DetailsPane::RequestDetails => app.request_details_list.select(),
-            DetailsPane::QueryParams => app.query_params_list.select(),
-            DetailsPane::RequestHeaders => app.request_headers_list.select(),
-            DetailsPane::ResponseDetails => app.response_details_list.select(),
-            DetailsPane::ResponseHeaders => app.response_headers_list.select(),
-            DetailsPane::Timing => app.timing_list.select(),
+            DetailsPane::RequestDetails => app.request_details_list.action(),
+            DetailsPane::QueryParams => app.query_params_list.action(),
+            DetailsPane::RequestHeaders => app.request_headers_list.action(),
+            DetailsPane::ResponseDetails => app.response_details_list.action(),
+            DetailsPane::ResponseHeaders => app.response_headers_list.action(),
+            DetailsPane::Timing => app.timing_list.action(),
         }
     } else {
         None
@@ -472,8 +472,8 @@ pub fn handle_tab(app: &mut Home) -> Option<Action> {
             FilterScreen::Actions => ActiveBlock::Filter(FilterScreen::Main),
         },
         ActiveBlock::Sort(screen) => match screen {
-            SortScreen::Source => ActiveBlock::Sort(SortScreen::Order),
-            SortScreen::Order => ActiveBlock::Sort(SortScreen::Actions),
+            SortScreen::Source => ActiveBlock::Sort(SortScreen::Direction),
+            SortScreen::Direction => ActiveBlock::Sort(SortScreen::Actions),
             SortScreen::Actions => ActiveBlock::Sort(SortScreen::Source),
         },
         _ => app.active_block,
@@ -507,8 +507,8 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
         },
         ActiveBlock::Sort(screen) => match screen {
             SortScreen::Source => ActiveBlock::Sort(SortScreen::Actions),
-            SortScreen::Order => ActiveBlock::Sort(SortScreen::Source),
-            SortScreen::Actions => ActiveBlock::Sort(SortScreen::Order),
+            SortScreen::Direction => ActiveBlock::Sort(SortScreen::Source),
+            SortScreen::Actions => ActiveBlock::Sort(SortScreen::Direction),
         },
         _ => app.active_block,
     };
@@ -941,10 +941,10 @@ pub fn handle_general_status(app: &mut Home, s: String) -> Option<Action> {
 
 pub fn handle_select(app: &mut Home) -> Option<Action> {
     match app.active_block {
-        ActiveBlock::Sort(SortScreen::Source) => app.sort_sources.select(),
-        ActiveBlock::Sort(SortScreen::Order) => app.sort_directions.select(),
-        ActiveBlock::Sort(SortScreen::Actions) => app.sort_actions.select(),
-        ActiveBlock::Filter(FilterScreen::Actions) => app.filter_actions.select(),
+        ActiveBlock::Sort(SortScreen::Source) => app.sort_sources.action(),
+        ActiveBlock::Sort(SortScreen::Direction) => app.sort_directions.action(),
+        ActiveBlock::Sort(SortScreen::Actions) => app.sort_actions.action(),
+        ActiveBlock::Filter(FilterScreen::Actions) => app.filter_actions.action(),
         ActiveBlock::Filter(FilterScreen::Main) => {
             let blocks = vec!["method", "source", "status"];
 
@@ -959,6 +959,7 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
                 };
 
                 app.filter_value_screen = screen;
+                app.filter_value_index = 0;
                 app.active_block = ActiveBlock::Filter(screen);
             };
 

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -782,7 +782,7 @@ pub fn handle_go_to_end(app: &mut Home, additional_metadata: HandlerMetadata) ->
 
                         if requires_scrollbar {
                             let current_index_hit_viewport_end =
-                                app.request_headers_list.state.offset() >= {
+                                app.request_headers_list.scroll_state.offset() >= {
                                     usable_height as usize
                                 };
 
@@ -827,7 +827,7 @@ pub fn handle_go_to_end(app: &mut Home, additional_metadata: HandlerMetadata) ->
 
                         if requires_scrollbar {
                             let current_index_hit_viewport_end =
-                                app.response_headers_list.state.offset() >= {
+                                app.response_headers_list.scroll_state.offset() >= {
                                     usable_height as usize
                                 };
 

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -400,24 +400,6 @@ pub fn handle_down(
     }
 }
 
-pub fn handle_enter(app: &mut Home) -> Option<Action> {
-    if app.active_block == ActiveBlock::Traces {
-        app.active_block = ActiveBlock::Details;
-        None
-    } else if app.active_block == ActiveBlock::Details {
-        match app.details_block {
-            DetailsPane::RequestDetails => app.request_details_list.action(),
-            DetailsPane::QueryParams => app.query_params_list.action(),
-            DetailsPane::RequestHeaders => app.request_headers_list.action(),
-            DetailsPane::ResponseDetails => app.response_details_list.action(),
-            DetailsPane::ResponseHeaders => app.response_headers_list.action(),
-            DetailsPane::Timing => app.timing_list.action(),
-        }
-    } else {
-        None
-    }
-}
-
 pub fn handle_esc(app: &mut Home) -> Option<Action> {
     app.active_block = ActiveBlock::Traces;
 
@@ -1098,7 +1080,22 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
             app.main.scroll_state = app.main.scroll_state.content_length(length.into());
 
             None
-        }
+        },
+        ActiveBlock::Traces => {
+            app.active_block = ActiveBlock::Details;
+
+            None
+        },
+        ActiveBlock::Details => {
+            match app.details_block {
+                DetailsPane::RequestDetails => app.request_details_list.action(),
+                DetailsPane::QueryParams => app.query_params_list.action(),
+                DetailsPane::RequestHeaders => app.request_headers_list.action(),
+                DetailsPane::ResponseDetails => app.response_details_list.action(),
+                DetailsPane::ResponseHeaders => app.response_headers_list.action(),
+                DetailsPane::Timing => app.timing_list.action(),
+            }
+        },
         _ => None,
     }
 }

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -467,17 +467,17 @@ pub fn handle_tab(app: &mut Home) -> Option<Action> {
         ActiveBlock::Details => ActiveBlock::ResponseBody,
         ActiveBlock::ResponseBody => ActiveBlock::RequestBody,
         ActiveBlock::RequestBody => ActiveBlock::Traces,
-        ActiveBlock::Sort(screen) => match screen {
-            SortScreen::SortMain => ActiveBlock::Sort(SortScreen::SortVariant),
-            SortScreen::SortVariant => ActiveBlock::Sort(SortScreen::SortActions),
-            SortScreen::SortActions => ActiveBlock::Sort(SortScreen::SortMain),
-        },
         ActiveBlock::Filter(screen) => match screen {
             FilterScreen::FilterMain => app.active_block,
             FilterScreen::FilterSource => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterMethod => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterStatus => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterActions => ActiveBlock::Filter(FilterScreen::FilterMain),
+        },
+        ActiveBlock::Sort(screen) => match screen {
+            SortScreen::SortMain => ActiveBlock::Sort(SortScreen::SortVariant),
+            SortScreen::SortVariant => ActiveBlock::Sort(SortScreen::SortActions),
+            SortScreen::SortActions => ActiveBlock::Sort(SortScreen::SortMain),
         },
         _ => app.active_block,
     };
@@ -507,6 +507,11 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
             FilterScreen::FilterMethod => ActiveBlock::Filter(FilterScreen::FilterMain),
             FilterScreen::FilterStatus => ActiveBlock::Filter(FilterScreen::FilterMain),
             FilterScreen::FilterActions => app.active_block,
+        },
+        ActiveBlock::Sort(screen) => match screen {
+            SortScreen::SortMain => ActiveBlock::Sort(SortScreen::SortActions),
+            SortScreen::SortVariant => ActiveBlock::Sort(SortScreen::SortMain),
+            SortScreen::SortActions => ActiveBlock::Sort(SortScreen::SortVariant),
         },
         _ => app.active_block,
     };

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -468,7 +468,7 @@ pub fn handle_tab(app: &mut Home) -> Option<Action> {
         ActiveBlock::ResponseBody => ActiveBlock::RequestBody,
         ActiveBlock::RequestBody => ActiveBlock::Traces,
         ActiveBlock::Filter(screen) => match screen {
-            FilterScreen::FilterMain => app.active_block,
+            FilterScreen::FilterMain => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterSource => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterMethod => ActiveBlock::Filter(FilterScreen::FilterActions),
             FilterScreen::FilterStatus => ActiveBlock::Filter(FilterScreen::FilterActions),
@@ -506,7 +506,7 @@ pub fn handle_back_tab(app: &mut Home) -> Option<Action> {
             FilterScreen::FilterSource => ActiveBlock::Filter(FilterScreen::FilterMain),
             FilterScreen::FilterMethod => ActiveBlock::Filter(FilterScreen::FilterMain),
             FilterScreen::FilterStatus => ActiveBlock::Filter(FilterScreen::FilterMain),
-            FilterScreen::FilterActions => app.active_block,
+            FilterScreen::FilterActions => ActiveBlock::Filter(FilterScreen::FilterMain),
         },
         ActiveBlock::Sort(screen) => match screen {
             SortScreen::SortMain => ActiveBlock::Sort(SortScreen::SortActions),
@@ -954,12 +954,15 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
             let maybe_selected_filter = blocks.iter().nth(app.filter_index).cloned();
 
             if let Some(selected_filter) = maybe_selected_filter {
-                match selected_filter {
-                    "method" => app.active_block = ActiveBlock::Filter(FilterScreen::FilterMethod),
-                    "source" => app.active_block = ActiveBlock::Filter(FilterScreen::FilterSource),
-                    "status" => app.active_block = ActiveBlock::Filter(FilterScreen::FilterStatus),
-                    _ => {}
-                }
+                let screen = match selected_filter {
+                    "method" => FilterScreen::FilterMethod,
+                    "source" => FilterScreen::FilterSource,
+                    "status" => FilterScreen::FilterStatus,
+                    _ => FilterScreen::default()
+                };
+
+                app.filter_value_screen = screen;
+                app.active_block = ActiveBlock::Filter(screen);
             };
 
             None

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -963,6 +963,8 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
                     order: SortOrder::Ascending,
                 };
 
+                app.sort_order_index = 0;
+
                 Some(Action::ActivateBlock(ActiveBlock::Sort(
                     SortScreen::SortVariant,
                 )))

--- a/src/components/handlers.rs
+++ b/src/components/handlers.rs
@@ -106,9 +106,17 @@ pub fn handle_up(
             _ => None,
         },
         _ => match (app.active_block, app.details_block) {
-            (ActiveBlock::Filter(_), _) => match app.filter_index.checked_sub(1) {
+            (ActiveBlock::Filter(FilterScreen::FilterMain), _) => match app.filter_index.checked_sub(1) {
                 Some(v) => {
                     app.filter_index = v;
+
+                    None
+                }
+                _ => None,
+            },
+            (ActiveBlock::Filter(_), _) => match app.filter_value_index.checked_sub(1) {
+                Some(v) => {
+                    app.filter_value_index = v;
 
                     None
                 }
@@ -311,15 +319,15 @@ pub fn handle_down(
         },
         _ => match (app.active_block, app.details_block) {
             (ActiveBlock::Filter(FilterScreen::FilterMethod), _) => {
-                if app.filter_index + 1 < app.method_filters.len() {
-                    app.filter_index += 1;
+                if app.filter_value_index + 1 < app.method_filters.len() {
+                    app.filter_value_index += 1;
                 }
 
                 None
             }
             (ActiveBlock::Filter(FilterScreen::FilterSource), _) => {
-                if app.filter_index + 1 < get_services_from_traces(app).len() + 1 {
-                    app.filter_index += 1;
+                if app.filter_value_index + 1 < get_services_from_traces(app).len() + 1 {
+                    app.filter_value_index += 1;
                 }
 
                 None
@@ -332,8 +340,8 @@ pub fn handle_down(
                 None
             }
             (ActiveBlock::Filter(FilterScreen::FilterStatus), _) => {
-                if app.filter_index + 1 < app.status_filters.len() {
-                    app.filter_index += 1;
+                if app.filter_value_index + 1 < app.status_filters.len() {
+                    app.filter_value_index += 1;
                 }
 
                 None
@@ -973,7 +981,7 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
 
             None
         }
-        ActiveBlock::Filter(crate::app::FilterScreen::FilterMain) => {
+        ActiveBlock::Filter(FilterScreen::FilterMain) => {
             let blocks = vec!["method", "source", "status"];
 
             let maybe_selected_filter = blocks.iter().nth(app.filter_index).cloned();
@@ -981,31 +989,20 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
             if let Some(selected_filter) = maybe_selected_filter {
                 match selected_filter {
                     "method" => {
-                        app.previous_blocks
-                            .push(ActiveBlock::Filter(crate::app::FilterScreen::FilterMain));
-
                         app.active_block =
-                            ActiveBlock::Filter(crate::app::FilterScreen::FilterMethod)
+                            ActiveBlock::Filter(FilterScreen::FilterMethod)
                     }
                     "source" => {
-                        app.previous_blocks
-                            .push(ActiveBlock::Filter(crate::app::FilterScreen::FilterMain));
-
                         app.active_block =
-                            ActiveBlock::Filter(crate::app::FilterScreen::FilterSource)
+                            ActiveBlock::Filter(FilterScreen::FilterSource)
                     }
                     "status" => {
-                        app.previous_blocks
-                            .push(ActiveBlock::Filter(crate::app::FilterScreen::FilterMain));
-
                         app.active_block =
-                            ActiveBlock::Filter(crate::app::FilterScreen::FilterStatus)
+                            ActiveBlock::Filter(FilterScreen::FilterStatus)
                     }
                     _ => {}
                 }
             };
-
-            app.filter_index = 0;
 
             None
         }
@@ -1015,7 +1012,7 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
                 .status_filters
                 .iter()
                 .map(|(key, _item)| key)
-                .nth(app.filter_index);
+                .nth(app.filter_value_index);
 
             if current_service.is_none() {
                 return None;
@@ -1046,12 +1043,12 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
 
             None
         }
-        ActiveBlock::Filter(crate::app::FilterScreen::FilterMethod) => {
+        ActiveBlock::Filter(FilterScreen::FilterMethod) => {
             let current_service = app
                 .method_filters
                 .iter()
                 .map(|(a, _item)| a)
-                .nth(app.filter_index);
+                .nth(app.filter_value_index);
 
             if current_service.is_none() {
                 return None;
@@ -1082,7 +1079,7 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
 
             None
         }
-        ActiveBlock::Filter(crate::app::FilterScreen::FilterSource) => {
+        ActiveBlock::Filter(FilterScreen::FilterSource) => {
             let mut services = get_services_from_traces(app);
 
             let mut a: Vec<String> = vec!["All".to_string()];
@@ -1091,7 +1088,7 @@ pub fn handle_select(app: &mut Home) -> Option<Action> {
 
             services = a;
 
-            let selected_filter = services.iter().nth(app.filter_index).cloned();
+            let selected_filter = services.iter().nth(app.filter_value_index).cloned();
 
             if selected_filter.is_none() {
                 return None;

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -81,6 +81,7 @@ pub struct Home {
 impl Home {
     pub fn new() -> Result<Home, Box<dyn Error>> {
         let config = Config::new()?;
+
         let home = Home {
             key_map: config.mapping.0,
             colors: config.colors.clone(),
@@ -114,14 +115,16 @@ impl Home {
                 ActionableListItem::with_label(SortSource::Timestamp.as_ref())
                     .with_action(Action::SelectSortSource(SortSource::Timestamp)),
             ])
-            .with_scroll_state(ListState::default().with_selected(Some(0))),
+            .with_scroll_state(ListState::default().with_selected(Some(0)))
+            .with_select_labels(),
             sort_directions: ActionableList::with_items(vec![
                 ActionableListItem::with_label(SortDirection::Ascending.as_ref())
                     .with_action(Action::SelectSortDirection(SortDirection::Ascending)),
                 ActionableListItem::with_label(SortDirection::Descending.as_ref())
                     .with_action(Action::SelectSortDirection(SortDirection::Descending)),
             ])
-            .with_scroll_state(ListState::default().with_selected(Some(0))),
+            .with_scroll_state(ListState::default().with_selected(Some(0)))
+            .with_select_labels(),
             sort_actions: ActionableList::with_items(vec![
                 ActionableListItem::with_label("apply").with_action(Action::UpdateSort)
             ]),

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -121,7 +121,7 @@ impl Home {
                     ActionableListItem::with_label(SortSource::Timestamp.as_ref())
                         .with_action(Action::SelectSortSource(SortSource::Timestamp)),
                 ],
-                ListState::default(),
+                ListState::default().with_selected(Some(0)),
             ),
             sort_directions: ActionableList::new(
                 vec![
@@ -130,7 +130,7 @@ impl Home {
                     ActionableListItem::with_label(SortDirection::Descending.as_ref())
                         .with_action(Action::SelectSortDirection(SortDirection::Descending)),
                 ],
-                ListState::default(),
+                ListState::default().with_selected(Some(0)),
             ),
             sort_actions: ActionableList::new(
                 vec![ActionableListItem::with_label("apply").with_action(Action::UpdateSort)],
@@ -471,13 +471,14 @@ impl Component for Home {
                     return Ok(Some(Action::QuitApplication));
                 }
 
-                self.filter_source_index = 0;
-                self.filter_value_index = 0;
-
                 if let ActiveBlock::Filter(_) = self.active_block {
+                    self.filter_source_index = 0;
+                    self.filter_value_index = 0;
                     self.selected_filter = TraceFilter::default();
                 }
                 if let ActiveBlock::Sort(_) = self.active_block {
+                    self.sort_sources.select(0);
+                    self.sort_directions.select(0);
                     self.selected_sort = TraceSort::default();
                 }
 
@@ -613,7 +614,7 @@ impl Component for Home {
                     source,
                 };
                 Ok(Some(Action::ActivateBlock(ActiveBlock::Sort(
-                    SortScreen::Source,
+                    SortScreen::Direction,
                 ))))
             }
             Action::UpdateSort => {

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::AbortHandle;
 
 use crate::{
+    app::FilterScreen,
     app::{Action, ActiveBlock, DetailsPane, Mode, UIState},
     components::component::Component,
     components::handlers,
@@ -85,6 +86,7 @@ pub struct Home {
     pub response_json_viewer: jsonviewer::JSONViewer,
     pub selected_trace: Option<Trace>,
     pub filter_index: usize,
+    pub filter_value_index: usize,
     pub sort_index: usize,
     pub metadata: Option<handlers::HandlerMetadata>,
     pub filter_source: FilterSource,
@@ -235,6 +237,7 @@ impl Component for Home {
                 }
 
                 self.filter_index = 0;
+                self.filter_value_index = 0;
 
                 self.active_block = last_block.unwrap();
 
@@ -251,7 +254,7 @@ impl Component for Home {
 
                 self.previous_blocks.push(current_block);
 
-                self.active_block = ActiveBlock::Filter(crate::app::FilterScreen::FilterMain);
+                self.active_block = ActiveBlock::Filter(FilterScreen::FilterMain);
 
                 Ok(None)
             }
@@ -328,41 +331,14 @@ impl Component for Home {
 
                 render::render_help(self, frame, main_layout[0]);
             }
-            ActiveBlock::Filter(crate::app::FilterScreen::FilterMain) => {
+            ActiveBlock::Filter(filter_screen) => {
                 let main_layout = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(3)
                     .constraints([Constraint::Percentage(100)].as_ref())
                     .split(frame.size());
 
-                render::render_filters(self, frame, main_layout[0]);
-            }
-            ActiveBlock::Filter(crate::app::FilterScreen::FilterSource) => {
-                let main_layout = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(3)
-                    .constraints([Constraint::Percentage(100)].as_ref())
-                    .split(frame.size());
-
-                render::render_filters_source(self, frame, main_layout[0]);
-            }
-            ActiveBlock::Filter(crate::app::FilterScreen::FilterStatus) => {
-                let main_layout = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(3)
-                    .constraints([Constraint::Percentage(100)].as_ref())
-                    .split(frame.size());
-
-                render::render_filters_status(self, frame, main_layout[0]);
-            }
-            ActiveBlock::Filter(crate::app::FilterScreen::FilterMethod) => {
-                let main_layout = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(3)
-                    .constraints([Constraint::Percentage(100)].as_ref())
-                    .split(frame.size());
-
-                render::render_filters_method(self, frame, main_layout[0]);
+                render::render_filters(self, frame, main_layout[0], filter_screen);
             }
             ActiveBlock::Sort => {
                 let main_layout = Layout::default()

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -91,15 +91,16 @@ pub struct Home {
     pub selected_trace: Option<Trace>,
     pub filter_index: usize,
     pub filter_value_index: usize,
+    pub filter_value_screen: FilterScreen,
     pub filter_actions: ActionableList,
+    pub filter_source: FilterSource,
+    pub selected_filter_source: FilterSource,
     pub sort_sources: ActionableList,
     pub sort_ordering: ActionableList,
     pub sort_actions: ActionableList,
     pub sort: TraceSort,
     pub selected_sort: TraceSort,
     pub metadata: Option<handlers::HandlerMetadata>,
-    pub filter_source: FilterSource,
-    pub selected_filter_source: FilterSource,
     pub method_filters: HashMap<http::method::Method, MethodFilter>,
     pub status_filters: HashMap<String, StatusFilter>,
     pub details_block: DetailsPane,
@@ -612,7 +613,20 @@ impl Component for Home {
                 Ok(None)
             }
             Action::ActivateBlock(block) => {
+                if block == ActiveBlock::Sort(SortScreen::SortActions) {
+                    self.sort_actions.next();
+                } else {
+                    self.sort_actions.reset();
+                }
+
+                if block == ActiveBlock::Filter(FilterScreen::FilterActions) {
+                    self.filter_actions.next();
+                } else {
+                    self.filter_actions.reset();
+                }
+
                 self.active_block = block;
+
                 Ok(None)
             }
             Action::SelectSortOrder(order) => {
@@ -656,14 +670,14 @@ impl Component for Home {
 
                 render::render_help(self, frame, main_layout[0]);
             }
-            ActiveBlock::Filter(filter_screen) => {
+            ActiveBlock::Filter(_) => {
                 let main_layout = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(3)
                     .constraints([Constraint::Percentage(100)].as_ref())
                     .split(frame.size());
 
-                render::render_filters(self, frame, main_layout[0], filter_screen);
+                render::render_filters(self, frame, main_layout[0]);
             }
             ActiveBlock::Sort(_) => {
                 let main_layout = Layout::default()

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -96,44 +96,35 @@ impl Home {
                 "Response body",
                 config.colors.clone(),
             )?,
-            filter_actions: ActionableList::new(
-                vec![ActionableListItem::with_label("apply").with_action(Action::UpdateFilter)],
-                ListState::default(),
-                ListState::default(),
-            ),
-            sort_sources: ActionableList::new(
-                vec![
-                    ActionableListItem::with_label(SortSource::Method.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Method)),
-                    ActionableListItem::with_label(SortSource::Status.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Status)),
-                    ActionableListItem::with_label(SortSource::Source.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Source)),
-                    ActionableListItem::with_label(SortSource::Url.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Url)),
-                    ActionableListItem::with_label(SortSource::Duration.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Duration)),
-                    ActionableListItem::with_label(SortSource::Timestamp.as_ref())
-                        .with_action(Action::SelectSortSource(SortSource::Timestamp)),
-                ],
-                ListState::default().with_selected(Some(0)),
-                ListState::default(),
-            ),
-            sort_directions: ActionableList::new(
-                vec![
-                    ActionableListItem::with_label(SortDirection::Ascending.as_ref())
-                        .with_action(Action::SelectSortDirection(SortDirection::Ascending)),
-                    ActionableListItem::with_label(SortDirection::Descending.as_ref())
-                        .with_action(Action::SelectSortDirection(SortDirection::Descending)),
-                ],
-                ListState::default().with_selected(Some(0)),
-                ListState::default(),
-            ),
-            sort_actions: ActionableList::new(
-                vec![ActionableListItem::with_label("apply").with_action(Action::UpdateSort)],
-                ListState::default(),
-                ListState::default(),
-            ),
+            filter_actions: ActionableList::with_items(vec![ActionableListItem::with_label(
+                "apply",
+            )
+            .with_action(Action::UpdateFilter)]),
+            sort_sources: ActionableList::with_items(vec![
+                ActionableListItem::with_label(SortSource::Method.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Method)),
+                ActionableListItem::with_label(SortSource::Status.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Status)),
+                ActionableListItem::with_label(SortSource::Source.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Source)),
+                ActionableListItem::with_label(SortSource::Url.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Url)),
+                ActionableListItem::with_label(SortSource::Duration.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Duration)),
+                ActionableListItem::with_label(SortSource::Timestamp.as_ref())
+                    .with_action(Action::SelectSortSource(SortSource::Timestamp)),
+            ])
+            .with_scroll_state(ListState::default().with_selected(Some(0))),
+            sort_directions: ActionableList::with_items(vec![
+                ActionableListItem::with_label(SortDirection::Ascending.as_ref())
+                    .with_action(Action::SelectSortDirection(SortDirection::Ascending)),
+                ActionableListItem::with_label(SortDirection::Descending.as_ref())
+                    .with_action(Action::SelectSortDirection(SortDirection::Descending)),
+            ])
+            .with_scroll_state(ListState::default().with_selected(Some(0))),
+            sort_actions: ActionableList::with_items(vec![
+                ActionableListItem::with_label("apply").with_action(Action::UpdateSort)
+            ]),
             details_tabs: DetailsPane::iter().collect(),
             details_panes: vec![],
             ..Self::default()
@@ -201,11 +192,7 @@ impl Home {
                 )
             };
 
-            self.request_details_list = ActionableList::new(
-                rows,
-                self.request_details_list.scroll_state.clone(),
-                self.request_details_list.select_state.clone(),
-            );
+            self.request_details_list = ActionableList::with_items(rows);
 
             // QUERY PARAMS PANE
             let mut raw_params = parse_query_params(
@@ -242,11 +229,7 @@ impl Home {
                 )
             };
 
-            self.query_params_list = ActionableList::new(
-                next_items,
-                self.query_params_list.scroll_state.clone(),
-                self.query_params_list.select_state.clone(),
-            );
+            self.query_params_list = ActionableList::with_items(next_items);
 
             // RESPONSE DETAILS PANE
             let mut items: Vec<ActionableListItem> = vec![];
@@ -291,11 +274,7 @@ impl Home {
                 )
             };
 
-            self.response_details_list = ActionableList::new(
-                items,
-                self.response_details_list.scroll_state.clone(),
-                self.response_details_list.select_state.clone(),
-            );
+            self.response_details_list = ActionableList::with_items(items);
 
             // REQUEST HEADERS PANE
             let headers = trace.http.clone().unwrap_or_default().request_headers;
@@ -329,11 +308,7 @@ impl Home {
                 )
             };
 
-            self.request_headers_list = ActionableList::new(
-                next_items,
-                self.request_headers_list.scroll_state.clone(),
-                self.request_headers_list.select_state.clone(),
-            );
+            self.request_headers_list = ActionableList::with_items(next_items);
 
             // RESPONSE HEADERS PANE
             let headers = trace.http.clone().unwrap_or_default().response_headers;
@@ -368,11 +343,7 @@ impl Home {
                 )
             };
 
-            self.response_headers_list = ActionableList::new(
-                next_items,
-                self.response_headers_list.scroll_state.clone(),
-                self.response_headers_list.select_state.clone(),
-            );
+            self.response_headers_list = ActionableList::with_items(next_items);
 
             // TIMING PANE
             let next_items: Vec<ActionableListItem> = vec![
@@ -385,11 +356,7 @@ impl Home {
                 ActionableListItem::with_label("receiving"),
             ];
 
-            self.timing_list = ActionableList::new(
-                next_items,
-                self.timing_list.scroll_state.clone(),
-                self.timing_list.select_state.clone(),
-            );
+            self.timing_list = ActionableList::with_items(next_items);
         }
     }
 }

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -504,6 +504,13 @@ impl Component for Home {
                 self.filter_index = 0;
                 self.filter_value_index = 0;
 
+                if let ActiveBlock::Filter(_) = self.active_block {
+                    self.selected_filter_source = FilterSource::default();
+                }
+                if let ActiveBlock::Sort(_) = self.active_block {
+                    self.selected_sort = TraceSort::default();
+                }
+
                 self.active_block = last_block.unwrap();
 
                 Ok(None)

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -115,16 +115,14 @@ impl Home {
                 ActionableListItem::with_label(SortSource::Timestamp.as_ref())
                     .with_action(Action::SelectSortSource(SortSource::Timestamp)),
             ])
-            .with_scroll_state(ListState::default().with_selected(Some(0)))
-            .with_select_labels(),
+            .with_scroll_state(ListState::default().with_selected(Some(0))),
             sort_directions: ActionableList::with_items(vec![
                 ActionableListItem::with_label(SortDirection::Ascending.as_ref())
                     .with_action(Action::SelectSortDirection(SortDirection::Ascending)),
                 ActionableListItem::with_label(SortDirection::Descending.as_ref())
                     .with_action(Action::SelectSortDirection(SortDirection::Descending)),
             ])
-            .with_scroll_state(ListState::default().with_selected(Some(0)))
-            .with_select_labels(),
+            .with_scroll_state(ListState::default().with_selected(Some(0))),
             sort_actions: ActionableList::with_items(vec![
                 ActionableListItem::with_label("apply").with_action(Action::UpdateSort)
             ]),

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -475,7 +475,6 @@ impl Component for Home {
             Action::UpdateSearchQuery(c) => Ok(handlers::handle_search_push(self, c)),
             Action::DeleteSearchQuery => Ok(handlers::handle_search_pop(self)),
             Action::ExitSearch => Ok(handlers::handle_search_exit(self)),
-            Action::ShowTraceDetails => Ok(handlers::handle_enter(self)),
             Action::FocusOnTraces => Ok(handlers::handle_esc(self)),
             Action::StopWebSocketServer => {
                 self.wss_connected = false;
@@ -659,12 +658,9 @@ impl Component for Home {
                         .direction(Direction::Horizontal)
                         .constraints(
                             [Constraint::Percentage(35), Constraint::Percentage(65)].as_ref(),
-                        )
-                        .split(main_layout[0]);
+                        );
 
-                    let [left_column, right_column, ..] = main_columns[..] else {
-                        todo!()
-                    };
+                    let [left_column, right_column] = main_columns.areas(main_layout[0]);
 
                     let right_column_layout = Layout::default()
                         .direction(Direction::Vertical)

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -91,6 +91,7 @@ pub struct Home {
     pub selected_trace: Option<Trace>,
     pub filter_index: usize,
     pub filter_value_index: usize,
+    pub filter_actions: ActionableList,
     pub sort_sources: ActionableList,
     pub sort_ordering: ActionableList,
     pub sort_actions: ActionableList,
@@ -98,6 +99,7 @@ pub struct Home {
     pub selected_sort: TraceSort,
     pub metadata: Option<handlers::HandlerMetadata>,
     pub filter_source: FilterSource,
+    pub selected_filter_source: FilterSource,
     pub method_filters: HashMap<http::method::Method, MethodFilter>,
     pub status_filters: HashMap<String, StatusFilter>,
     pub details_block: DetailsPane,
@@ -130,6 +132,10 @@ impl Home {
                 "Response body",
                 config.colors.clone(),
             )?,
+            filter_actions: ActionableList::new(
+                vec![ActionableListItem::with_label("apply").with_action(Action::UpdateFilter)],
+                ListState::default(),
+            ),
             sort_sources: ActionableList::new(
                 vec![
                     ActionableListItem::with_label(SortSource::Method.as_ref())
@@ -198,10 +204,6 @@ impl Home {
 
     pub fn get_filter_source(&self) -> &FilterSource {
         &self.filter_source
-    }
-
-    pub fn set_filter_source(&mut self, f: FilterSource) {
-        self.filter_source = f
     }
 
     fn mark_trace_as_timed_out(&mut self, id: String) {
@@ -626,6 +628,10 @@ impl Component for Home {
             }
             Action::UpdateSort => {
                 self.sort = self.selected_sort.clone();
+                Ok(Some(Action::ActivateBlock(ActiveBlock::Traces)))
+            }
+            Action::UpdateFilter => {
+                self.filter_source = self.selected_filter_source.clone();
                 Ok(Some(Action::ActivateBlock(ActiveBlock::Traces)))
             }
             _ => Ok(None),

--- a/src/components/jsonviewer.rs
+++ b/src/components/jsonviewer.rs
@@ -210,21 +210,25 @@ impl JSONViewer {
             .constraints([Constraint::Length(4), Constraint::Min(0)])
             .split(inner_area);
 
-        let mut lines = raw_lines(
+        let raw_lines = raw_lines(
             self.data.clone(),
             self.expanded_idxs.clone(),
             self.is_expanded,
         )?;
 
-        for (idx, line) in lines.iter_mut().enumerate() {
-            let style = match (self.is_active, idx == self.cursor_position) {
-                (true, true) => get_row_style(RowStyle::Selected, &self.colors),
-                (true, false) => get_row_style(RowStyle::Active, &self.colors),
-                (false, true) => get_row_style(RowStyle::Inactive, &self.colors),
-                (false, false) => get_row_style(RowStyle::Default, &self.colors),
-            };
-            line.patch_style(style);
-        }
+        let mut lines: Vec<Line> = raw_lines
+            .iter()
+            .enumerate()
+            .map(|(idx, line)| {
+                let style = match (self.is_active, idx == self.cursor_position) {
+                    (true, true) => get_row_style(RowStyle::Selected, &self.colors),
+                    (true, false) => get_row_style(RowStyle::Active, &self.colors),
+                    (false, true) => get_row_style(RowStyle::Inactive, &self.colors),
+                    (false, false) => get_row_style(RowStyle::Default, &self.colors),
+                };
+                line.clone().patch_style(style)
+            })
+            .collect();
 
         let mut indent: usize = 0;
         for line in lines.iter_mut() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1213,7 +1213,7 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         .direction(Direction::Horizontal)
         .split(footer_rect);
 
-    let sort = format!("{}", app.sort.to_string().to_lowercase());
+    let sort = format!("{}", app.selected_sort.to_string().to_lowercase());
     let footer_content = Paragraph::new(vec![
         Line::raw(""),
         Line::from(vec![Span::styled(

--- a/src/render.rs
+++ b/src/render.rs
@@ -969,12 +969,7 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                         RowStyle::Default
                     };
 
-                    let middle = Cell::from(
-                        Line::from(vec![Span::raw("Source".to_string())])
-                            .alignment(Alignment::Left),
-                    );
-
-                    return Row::new(vec![column_b, middle, column_a])
+                    return Row::new(vec![column_b, column_a])
                         .style(get_row_style(row_style, app.colors.clone()));
                 }
                 FilterSource::Applied(applied) => {
@@ -999,12 +994,7 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                         RowStyle::Default
                     };
 
-                    let middle = Cell::from(
-                        Line::from(vec![Span::raw("Source".to_string())])
-                            .alignment(Alignment::Left),
-                    );
-
-                    return Row::new(vec![column_b, middle, column_a])
+                    return Row::new(vec![column_b, column_a])
                         .style(get_row_style(row_style, app.colors.clone()));
                 }
             };
@@ -1054,12 +1044,7 @@ pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
                     RowStyle::Default
                 };
 
-            let h = Cell::from(
-                Line::from(vec![Span::raw("Status".to_string())]).alignment(Alignment::Left),
-            );
-
-            Row::new(vec![column_b, h, column_a])
-                .style(get_row_style(row_style, app.colors.clone()))
+            Row::new(vec![column_b, column_a]).style(get_row_style(row_style, app.colors.clone()))
         })
         .collect::<Vec<_>>();
 
@@ -1109,12 +1094,7 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
                 RowStyle::Default
             };
 
-            let h = Cell::from(
-                Line::from(vec![Span::raw("Method".to_string())]).alignment(Alignment::Left),
-            );
-
-            Row::new(vec![column_b, h, column_a])
-                .style(get_row_style(row_style, app.colors.clone()))
+            Row::new(vec![column_b, column_a]).style(get_row_style(row_style, app.colors.clone()))
         })
         .collect::<Vec<_>>();
 
@@ -1142,7 +1122,7 @@ pub fn render_filters(app: &Home, frame: &mut Frame, area: Rect, filter_screen: 
     frame.render_widget(parent_block, area);
 
     let vertical_layout = Layout::default()
-        .constraints([Constraint::Min(0), Constraint::Length(3)])
+        .constraints([Constraint::Min(0), Constraint::Length(4)])
         .horizontal_margin(1)
         .direction(Direction::Vertical)
         .split(inner_area);
@@ -1202,9 +1182,55 @@ pub fn render_filters(app: &Home, frame: &mut Frame, area: Rect, filter_screen: 
         .border_set(symbols::border::DOUBLE)
         .border_style(get_border_style(true, app.colors.clone()));
 
+    let footer_rect = footer.inner(vertical_layout[1]);
+    let method_filters = app
+        .method_filters
+        .values()
+        .filter(|v| v.selected)
+        .map(|v| v.name.clone())
+        .map(|s| format!("method-{}", s.to_lowercase()))
+        .collect::<Vec<_>>();
+    let source_filters: Vec<String> = if let FilterSource::Applied(hashset) = &app.filter_source {
+        hashset
+            .iter()
+            .map(|s| format!("source-{}", s.to_lowercase()))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let status_filters: Vec<String> = app
+        .status_filters
+        .values()
+        .filter(|v| v.selected)
+        .map(|v| v.name.clone())
+        .map(|s| format!("status-{}", s.to_lowercase()))
+        .collect();
+
+    let filters = [method_filters, source_filters, status_filters]
+        .concat()
+        .join(", ");
+
+    let footer_content = Paragraph::new(vec![
+        Line::raw(""),
+        Line::from(vec![Span::styled(
+            format!(
+                "filter: {}",
+                if filters.len() > 0 {
+                    filters
+                } else {
+                    "none".into()
+                }
+            ),
+            Style::default().fg(app.colors.text.accent_2),
+        )]),
+        Line::raw(""),
+    ]);
+
     frame.render_widget(list, layout[0]);
     frame.render_widget(divider, layout[1]);
     frame.render_widget(footer, vertical_layout[1]);
+    frame.render_widget(footer_content, footer_rect);
 
     match filter_screen {
         FilterScreen::FilterMain => {}

--- a/src/render.rs
+++ b/src/render.rs
@@ -698,6 +698,11 @@ pub fn render_help(app: &Home, frame: &mut Frame, area: Rect) {
                 Action::PreviousDetailsTab => "Go To Previous Tab",
                 Action::StartWebSocketServer => "Start the Collector Server",
                 Action::StopWebSocketServer => "Stop the Collector Server",
+                Action::Select => "Select at cursor position",
+                Action::ExpandAll => "Expand all JSON objects",
+                Action::CollapseAll => "Collapse all JSON objects",
+                Action::OpenSort => "Open sort screen",
+                Action::OpenFilter => "Open filter screen",
                 _ => "",
             };
             let description = format!("{}:", description_str);
@@ -1003,18 +1008,7 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
             let is_selected_row = current_filter == Some(item);
             let is_active = is_active_block && is_selected_row;
             let is_inactive = !is_active && is_selected_row;
-            let is_selected = match item {
-                &"method" => filter_screen == FilterScreen::Method,
-                &"source" => filter_screen == FilterScreen::Source,
-                &"status" => filter_screen == FilterScreen::Status,
-                _ => false,
-            };
-            let label = if is_selected { "[x]" } else { "[ ]" };
-
-            let column_a = Cell::from(
-                Line::from(vec![Span::raw(label.to_string())]).alignment(Alignment::Left),
-            );
-            let column_b = Cell::from(
+            let column = Cell::from(
                 Line::from(vec![Span::raw(item.to_string())]).alignment(Alignment::Left),
             );
 
@@ -1027,24 +1021,21 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
             };
 
             if let Some(row_style) = maybe_row_style {
-                Row::new(vec![column_a, column_b]).style(get_row_style(row_style, &app.colors))
+                Row::new(vec![column]).style(get_row_style(row_style, &app.colors))
             } else {
-                Row::new(vec![column_a, column_b])
+                Row::new(vec![column])
             }
         })
         .collect::<Vec<_>>();
 
-    let table = Table::new(
-        [filter_item_rows].concat(),
-        &[Constraint::Length(3), Constraint::Percentage(100)],
-    )
-    .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
-    .style(if filter_screen == FilterScreen::Main {
-        get_row_style(RowStyle::Active, &app.colors)
-    } else {
-        get_row_style(RowStyle::Default, &app.colors)
-    })
-    .column_spacing(3);
+    let table = Table::new([filter_item_rows].concat(), &[Constraint::Percentage(100)])
+        .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
+        .style(if filter_screen == FilterScreen::Main {
+            get_row_style(RowStyle::Active, &app.colors)
+        } else {
+            get_row_style(RowStyle::Default, &app.colors)
+        })
+        .column_spacing(3);
 
     let divider = Block::default()
         .borders(Borders::LEFT)
@@ -1156,6 +1147,8 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         .constraints([
             Constraint::Percentage(50),
             Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
             Constraint::Percentage(50),
         ])
         .vertical_margin(1)
@@ -1205,11 +1198,11 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         &app.colors,
         app.active_block == ActiveBlock::Sort(SortScreen::Source),
     );
-    frame.render_widget(divider, layout[1]);
+    frame.render_widget(divider, layout[2]);
     render_selectable_list(
         &mut app.sort_directions,
         frame,
-        layout[2],
+        layout[4],
         &app.colors,
         app.active_block == ActiveBlock::Sort(SortScreen::Direction),
     );

--- a/src/render.rs
+++ b/src/render.rs
@@ -1247,20 +1247,29 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         .border_style(get_border_style(true, &app.colors));
 
     let footer_rect = footer.inner(vertical_layout[1]);
-    let footer_layout = Layout::default()
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .direction(Direction::Horizontal)
+    let footer_vertical_layout = Layout::default()
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .direction(Direction::Vertical)
         .split(footer_rect);
 
+    let footer_layout = Layout::default()
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Min(0),
+            Constraint::Length(5),
+        ])
+        .direction(Direction::Horizontal)
+        .split(footer_vertical_layout[1]);
+
     let sort = format!("{}", app.selected_sort.to_string().to_lowercase());
-    let footer_content = Paragraph::new(vec![
-        Line::raw(""),
-        Line::from(vec![Span::styled(
-            format!("sort: {}", sort),
-            Style::default().fg(app.colors.text.accent_2),
-        )]),
-        Line::raw(""),
-    ]);
+    let footer_content = Paragraph::new(vec![Line::from(vec![Span::styled(
+        format!("sort: {}", sort),
+        Style::default().fg(app.colors.text.accent_2),
+    )])]);
 
     render_actionable_list(
         &mut app.sort_sources,
@@ -1282,7 +1291,7 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
     render_actionable_list(
         &mut app.sort_actions,
         frame,
-        footer_layout[1],
+        footer_layout[2],
         &app.colors,
         app.active_block == ActiveBlock::Sort(SortScreen::SortActions),
     );

--- a/src/render.rs
+++ b/src/render.rs
@@ -865,6 +865,8 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
 
     let current_service = services.iter().nth(app.filter_value_index).cloned();
 
+    let is_active = app.active_block == ActiveBlock::Filter(FilterScreen::FilterSource);
+
     let rows = services
         .iter()
         .map(|item| {
@@ -877,10 +879,11 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                         Line::from(vec![Span::raw("[x]".to_string())]).alignment(Alignment::Left),
                     );
 
-                    let row_style = if current_service.is_some()
-                        && current_service.clone().unwrap() == item.deref()
-                    {
+                    let is_selected = current_service == Some(item.to_string());
+                    let row_style = if is_active && is_selected {
                         RowStyle::Selected
+                    } else if is_selected {
+                        RowStyle::Inactive
                     } else {
                         RowStyle::Default
                     };
@@ -902,10 +905,12 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                         )
                     };
 
-                    let row_style = if current_service.is_some()
-                        && current_service.clone().unwrap() == item.deref()
-                    {
+                    let is_selected = current_service == Some(item.to_string());
+
+                    let row_style = if is_active && is_selected {
                         RowStyle::Selected
+                    } else if is_selected {
+                        RowStyle::Inactive
                     } else {
                         RowStyle::Default
                     };
@@ -919,7 +924,7 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
 
     let list = Table::new([rows].concat())
         .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
-        .style(get_text_style(true, &app.colors))
+        .style(get_text_style(is_active, &app.colors))
         .widths(&[
             Constraint::Percentage(15),
             Constraint::Percentage(15),
@@ -927,11 +932,13 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
         ])
         .column_spacing(10);
 
-    frame.render_widget(list.clone(), area);
+    frame.render_widget(list, area);
 }
 
 pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
     let current_service = app.status_filters.iter().nth(app.filter_value_index);
+
+    let is_active = app.active_block == ActiveBlock::Filter(FilterScreen::FilterStatus);
 
     let rows1 = app
         .status_filters
@@ -953,12 +960,15 @@ pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
 
             let (_key, status_filter) = current_service.clone().unwrap();
 
-            let row_style =
-                if current_service.is_some() && status_filter.status == item.name.clone() {
-                    RowStyle::Selected
-                } else {
-                    RowStyle::Default
-                };
+            let is_selected = status_filter.status == item.name.clone();
+
+            let row_style = if is_active && is_selected {
+                RowStyle::Selected
+            } else if is_selected {
+                RowStyle::Inactive
+            } else {
+                RowStyle::Default
+            };
 
             Row::new(vec![column_b, column_a]).style(get_row_style(row_style, &app.colors))
         })
@@ -966,7 +976,7 @@ pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
 
     let list = Table::new([rows1].concat())
         .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
-        .style(get_text_style(true, &app.colors))
+        .style(get_text_style(is_active, &app.colors))
         .widths(&[
             Constraint::Percentage(15),
             Constraint::Percentage(15),
@@ -974,7 +984,7 @@ pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
         ])
         .column_spacing(10);
 
-    frame.render_widget(list.clone(), area);
+    frame.render_widget(list, area);
 }
 
 pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
@@ -983,6 +993,8 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
         .iter()
         .map(|(_a, b)| b.name.clone())
         .nth(app.filter_value_index);
+
+    let is_active = app.active_block == ActiveBlock::Filter(FilterScreen::FilterMethod);
 
     let rows1 = app
         .method_filters
@@ -1002,10 +1014,12 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
                 )
             };
 
-            let row_style = if current_service.is_some()
-                && current_service.clone().unwrap() == item.name.clone()
-            {
+            let is_selected = current_service == Some(item.name.clone());
+
+            let row_style = if is_active && is_selected {
                 RowStyle::Selected
+            } else if is_selected {
+                RowStyle::Inactive
             } else {
                 RowStyle::Default
             };
@@ -1016,7 +1030,7 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
 
     let list = Table::new([rows1].concat())
         .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
-        .style(get_text_style(true, &app.colors))
+        .style(get_text_style(is_active, &app.colors))
         .widths(&[
             Constraint::Percentage(15),
             Constraint::Percentage(15),
@@ -1024,10 +1038,16 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
         ])
         .column_spacing(10);
 
-    frame.render_widget(list.clone(), area);
+    frame.render_widget(list, area);
 }
 
-pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_screen: FilterScreen) {
+pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
+    let filter_screen = if let ActiveBlock::Filter(screen) = app.active_block {
+        screen
+    } else {
+        FilterScreen::FilterMain
+    };
+
     let parent_block = Block::default()
         .borders(Borders::ALL)
         .border_style(get_border_style(true, &app.colors))
@@ -1061,7 +1081,9 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
     let filter_item_rows = filter_items
         .iter()
         .map(|item| {
-            let is_active = current_filter == Some(item);
+            let is_active =
+                filter_screen == FilterScreen::FilterMain && current_filter == Some(item);
+            let is_inactive = current_filter == Some(item);
             let is_selected = match item {
                 &"method" => filter_screen == FilterScreen::FilterMethod,
                 &"source" => filter_screen == FilterScreen::FilterSource,
@@ -1079,6 +1101,8 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
 
             let row_style = if is_active {
                 RowStyle::Selected
+            } else if is_inactive {
+                RowStyle::Inactive
             } else {
                 RowStyle::Default
             };
@@ -1090,7 +1114,7 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
     let list = Table::new([filter_item_rows].concat())
         .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
         .style(get_text_style(
-            filter_screen == FilterScreen::FilterMain,
+            filter_screen == FilterScreen::FilterMethod,
             &app.colors,
         ))
         .widths(&[Constraint::Length(3), Constraint::Percentage(100)])
@@ -1105,7 +1129,6 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
         .border_set(symbols::border::DOUBLE)
         .border_style(get_border_style(true, &app.colors));
 
-    let footer_rect = footer.inner(vertical_layout[1]);
     let method_filters = app
         .method_filters
         .values()
@@ -1135,26 +1158,36 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
         .concat()
         .join(", ");
 
-    let footer_layout = Layout::default()
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .direction(Direction::Horizontal)
+    let footer_rect = footer.inner(vertical_layout[1]);
+    let footer_vertical_layout = Layout::default()
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .direction(Direction::Vertical)
         .split(footer_rect);
 
-    let footer_content = Paragraph::new(vec![
-        Line::raw(""),
-        Line::from(vec![Span::styled(
-            format!(
-                "filter: {}",
-                if filters.len() > 0 {
-                    filters
-                } else {
-                    "none".into()
-                }
-            ),
-            Style::default().fg(app.colors.text.accent_2),
-        )]),
-        Line::raw(""),
-    ]);
+    let footer_layout = Layout::default()
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Min(0),
+            Constraint::Length(5),
+        ])
+        .direction(Direction::Horizontal)
+        .split(footer_vertical_layout[1]);
+
+    let footer_content = Paragraph::new(vec![Line::from(vec![Span::styled(
+        format!(
+            "filter: {}",
+            if filters.len() > 0 {
+                filters
+            } else {
+                "none".into()
+            }
+        ),
+        Style::default().fg(app.colors.text.accent_2),
+    )])]);
 
     frame.render_widget(list, layout[0]);
     frame.render_widget(divider, layout[1]);
@@ -1163,12 +1196,12 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
     render_actionable_list(
         &mut app.filter_actions,
         frame,
-        footer_layout[1],
+        footer_layout[2],
         &app.colors,
         app.active_block == ActiveBlock::Filter(FilterScreen::FilterActions),
     );
 
-    match filter_screen {
+    match app.filter_value_screen {
         FilterScreen::FilterMain => {}
         FilterScreen::FilterActions => {}
         FilterScreen::FilterMethod => render_filters_method(app, frame, layout[2]),

--- a/src/render.rs
+++ b/src/render.rs
@@ -878,7 +878,7 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                     );
 
                     let row_style = if current_service.is_some()
-                        && current_service.clone().unwrap() == item.deref().clone()
+                        && current_service.clone().unwrap() == item.deref()
                     {
                         RowStyle::Selected
                     } else {
@@ -1056,12 +1056,18 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
 
     let filter_items = vec!["method", "source", "status"];
 
-    let current_filter = filter_items.iter().nth(app.filter_index).cloned();
+    let current_filter = filter_items.get(app.filter_index);
 
     let filter_item_rows = filter_items
         .iter()
         .map(|item| {
-            let is_selected = current_filter.unwrap_or_default() == *item;
+            let is_active = current_filter == Some(item);
+            let is_selected = match item {
+                &"method" => filter_screen == FilterScreen::FilterMethod,
+                &"source" => filter_screen == FilterScreen::FilterSource,
+                &"status" => filter_screen == FilterScreen::FilterStatus,
+                _ => false,
+            };
             let label = if is_selected { "[x]" } else { "[ ]" };
 
             let column_a = Cell::from(
@@ -1071,7 +1077,7 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect, filter_scre
                 Line::from(vec![Span::raw(item.to_string())]).alignment(Alignment::Left),
             );
 
-            let row_style = if is_selected {
+            let row_style = if is_active {
                 RowStyle::Selected
             } else {
                 RowStyle::Default

--- a/src/render.rs
+++ b/src/render.rs
@@ -1279,7 +1279,7 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         frame,
         layout[2],
         &app.colors,
-        app.active_block == ActiveBlock::Sort(SortScreen::Order),
+        app.active_block == ActiveBlock::Sort(SortScreen::Direction),
     );
     frame.render_widget(footer, vertical_layout[1]);
     frame.render_widget(footer_content, footer_layout[0]);

--- a/src/render.rs
+++ b/src/render.rs
@@ -271,7 +271,7 @@ pub fn details_tabs(app: &mut Home, frame: &mut Frame, area: Rect) {
         let is_active = app.active_block == ActiveBlock::Details
             && app.details_tabs.contains(&app.details_block);
 
-        let tabs = Tabs::new(app.details_tabs.iter().map(|t| t.to_string()).collect())
+        let tabs = Tabs::new(app.details_tabs.iter().map(|t| t.to_string()))
             .block(
                 Block::default()
                     .borders(Borders::BOTTOM)
@@ -543,36 +543,38 @@ pub fn render_traces(app: &Home, frame: &mut Frame, area: Rect) {
         })
         .collect();
 
-    let requests = Table::new(styled_rows)
-        // You can set the style of the entire Table.
-        .style(Style::default().fg(app.colors.surface.selected))
-        // It has an optional header, which is simply a Row always visible at the top.
-        .header(
-            Row::new(vec!["Method", "Status", "Request", "Duration"])
-                .style(Style::default().fg(app.colors.text.accent_1))
-                .bottom_margin(1),
-        )
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(get_border_style(
-                    app.active_block == ActiveBlock::Traces,
-                    &app.colors,
-                ))
-                .title(title)
-                .title(
-                    Title::from(format!("{} of {}", app.main.index + 1, number_of_lines))
-                        .position(Position::Bottom)
-                        .alignment(Alignment::Right),
-                )
-                .border_type(BorderType::Plain),
-        )
-        .widths(&[
+    let requests = Table::new(
+        styled_rows,
+        &[
             Constraint::Percentage(10),
             Constraint::Percentage(10),
             Constraint::Percentage(60),
             Constraint::Length(20),
-        ]);
+        ],
+    )
+    // You can set the style of the entire Table.
+    .style(Style::default().fg(app.colors.surface.selected))
+    // It has an optional header, which is simply a Row always visible at the top.
+    .header(
+        Row::new(vec!["Method", "Status", "Request", "Duration"])
+            .style(Style::default().fg(app.colors.text.accent_1))
+            .bottom_margin(1),
+    )
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(get_border_style(
+                app.active_block == ActiveBlock::Traces,
+                &app.colors,
+            ))
+            .title(title)
+            .title(
+                Title::from(format!("{} of {}", app.main.index + 1, number_of_lines))
+                    .position(Position::Bottom)
+                    .alignment(Alignment::Right),
+            )
+            .border_type(BorderType::Plain),
+    );
 
     let vertical_scroll = Scrollbar::new(ScrollbarOrientation::VerticalRight);
 
@@ -746,22 +748,24 @@ pub fn render_help(app: &Home, frame: &mut Frame, area: Rect) {
         })
         .collect::<Vec<_>>();
 
-    let list = Table::new(debug_lines)
-        .style(get_text_style(true, &app.colors))
-        .header(
-            Row::new(vec!["Action", "Map"])
-                .style(Style::default().fg(app.colors.text.accent_1))
-                .bottom_margin(1),
-        )
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(get_border_style(true, &app.colors))
-                .title("Key Mappings")
-                .border_type(BorderType::Plain),
-        )
-        .widths(&[Constraint::Percentage(40), Constraint::Percentage(60)])
-        .column_spacing(10);
+    let list = Table::new(
+        debug_lines,
+        &[Constraint::Percentage(40), Constraint::Percentage(60)],
+    )
+    .style(get_text_style(true, &app.colors))
+    .header(
+        Row::new(vec!["Action", "Map"])
+            .style(Style::default().fg(app.colors.text.accent_1))
+            .bottom_margin(1),
+    )
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(get_border_style(true, &app.colors))
+            .title("Key Mappings")
+            .border_type(BorderType::Plain),
+    )
+    .column_spacing(10);
 
     frame.render_widget(list, area);
 }
@@ -1030,15 +1034,17 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
         })
         .collect::<Vec<_>>();
 
-    let table = Table::new([filter_item_rows].concat())
-        .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
-        .style(if filter_screen == FilterScreen::Main {
-            get_row_style(RowStyle::Active, &app.colors)
-        } else {
-            get_row_style(RowStyle::Default, &app.colors)
-        })
-        .widths(&[Constraint::Length(3), Constraint::Percentage(100)])
-        .column_spacing(3);
+    let table = Table::new(
+        [filter_item_rows].concat(),
+        &[Constraint::Length(3), Constraint::Percentage(100)],
+    )
+    .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
+    .style(if filter_screen == FilterScreen::Main {
+        get_row_style(RowStyle::Active, &app.colors)
+    } else {
+        get_row_style(RowStyle::Default, &app.colors)
+    })
+    .column_spacing(3);
 
     let divider = Block::default()
         .borders(Borders::LEFT)
@@ -1054,8 +1060,7 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
         .method
         .values()
         .filter(|v| v.selected)
-        .map(|v| v.name.clone())
-        .map(|s| format!("method-{}", s.to_lowercase()))
+        .map(|v| format!("method-{}", v.name.to_lowercase()))
         .collect::<Vec<_>>();
     let source_filters: Vec<String> =
         if let SourceFilter::Applied(hashset) = &app.selected_filters.source {
@@ -1072,8 +1077,7 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
         .status
         .values()
         .filter(|v| v.selected)
-        .map(|v| v.name.clone())
-        .map(|s| format!("status-{}", s.to_lowercase()))
+        .map(|v| format!("status-{}", v.name.to_lowercase()))
         .collect();
 
     let filters = [method_filters, source_filters, status_filters]
@@ -1221,19 +1225,21 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
 }
 
 fn render_table(rows: Vec<Row>, frame: &mut Frame, area: Rect, colors: &Colors, active: bool) {
-    let table = Table::new([rows].concat())
-        .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
-        .style(if active {
-            get_row_style(RowStyle::Active, colors)
-        } else {
-            get_row_style(RowStyle::Default, colors)
-        })
-        .widths(&[
+    let table = Table::new(
+        [rows].concat(),
+        &[
             Constraint::Percentage(15),
             Constraint::Percentage(15),
             Constraint::Percentage(60),
-        ])
-        .column_spacing(10);
+        ],
+    )
+    .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
+    .style(if active {
+        get_row_style(RowStyle::Active, colors)
+    } else {
+        get_row_style(RowStyle::Default, colors)
+    })
+    .column_spacing(10);
 
     frame.render_widget(table, area);
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -814,30 +814,15 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
     let rows = services
         .iter()
         .map(|item| {
-            let column_a =
+            let column_b =
                 Cell::from(Line::from(vec![Span::raw(item.clone())]).alignment(Alignment::Left));
 
-            match &app.selected_filters.source {
-                SourceFilter::All => {
-                    let column_b = Cell::from(
-                        Line::from(vec![Span::raw("[x]".to_string())]).alignment(Alignment::Left),
-                    );
-
-                    let is_selected = current_service == Some(item.to_string());
-                    let row_style = if is_active && is_selected {
-                        RowStyle::Selected
-                    } else if is_selected {
-                        RowStyle::Inactive
-                    } else {
-                        RowStyle::Default
-                    };
-
-                    return Row::new(vec![column_b, column_a])
-                        .style(get_row_style(row_style, &app.colors));
-                }
+            let column_a = match &app.selected_filters.source {
+                SourceFilter::All => Cell::from(
+                    Line::from(vec![Span::raw("[x]".to_string())]).alignment(Alignment::Left),
+                ),
                 SourceFilter::Applied(applied) => {
-                    let is_selected = current_service == Some(item.to_string());
-                    let column_b = if applied.contains(item) {
+                    if applied.contains(item) {
                         Cell::from(
                             Line::from(vec![Span::raw("[x]".to_string())])
                                 .alignment(Alignment::Left),
@@ -847,20 +832,24 @@ pub fn render_filters_source(app: &Home, frame: &mut Frame, area: Rect) {
                             Line::from(vec![Span::raw("[ ]".to_string())])
                                 .alignment(Alignment::Left),
                         )
-                    };
-
-                    let row_style = if is_active && is_selected {
-                        RowStyle::Selected
-                    } else if is_selected {
-                        RowStyle::Inactive
-                    } else {
-                        RowStyle::Default
-                    };
-
-                    return Row::new(vec![column_b, column_a])
-                        .style(get_row_style(row_style, &app.colors));
+                    }
                 }
             };
+            let is_selected = current_service == Some(item.to_string());
+
+            let maybe_row_style = if is_active && is_selected {
+                Some(RowStyle::Selected)
+            } else if is_selected {
+                Some(RowStyle::Inactive)
+            } else {
+                None
+            };
+
+            if let Some(row_style) = maybe_row_style {
+                Row::new(vec![column_a, column_b]).style(get_row_style(row_style, &app.colors))
+            } else {
+                Row::new(vec![column_a, column_b])
+            }
         })
         .collect::<Vec<_>>();
 
@@ -899,15 +888,19 @@ pub fn render_filters_status(app: &Home, frame: &mut Frame, area: Rect) {
 
             let is_selected = status_filter.status == item.name.clone();
 
-            let row_style = if is_active && is_selected {
-                RowStyle::Selected
+            let maybe_row_style = if is_active && is_selected {
+                Some(RowStyle::Selected)
             } else if is_selected {
-                RowStyle::Inactive
+                Some(RowStyle::Inactive)
             } else {
-                RowStyle::Default
+                None
             };
 
-            Row::new(vec![column_b, column_a]).style(get_row_style(row_style, &app.colors))
+            if let Some(row_style) = maybe_row_style {
+                Row::new(vec![column_b, column_a]).style(get_row_style(row_style, &app.colors))
+            } else {
+                Row::new(vec![column_b, column_a])
+            }
         })
         .collect::<Vec<_>>();
 
@@ -945,15 +938,19 @@ pub fn render_filters_method(app: &Home, frame: &mut Frame, area: Rect) {
 
             let is_selected = current_service == Some(item.name.clone());
 
-            let row_style = if is_active && is_selected {
-                RowStyle::Selected
+            let maybe_row_style = if is_active && is_selected {
+                Some(RowStyle::Selected)
             } else if is_selected {
-                RowStyle::Inactive
+                Some(RowStyle::Inactive)
             } else {
-                RowStyle::Default
+                None
             };
 
-            Row::new(vec![column_b, column_a]).style(get_row_style(row_style, &app.colors))
+            if let Some(row_style) = maybe_row_style {
+                Row::new(vec![column_b, column_a]).style(get_row_style(row_style, &app.colors))
+            } else {
+                Row::new(vec![column_b, column_a])
+            }
         })
         .collect::<Vec<_>>();
 
@@ -995,12 +992,13 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
     let filter_items = vec!["method", "source", "status"];
 
     let current_filter = filter_items.get(app.filter_source_index);
-
+    let is_active_block = filter_screen == FilterScreen::Main;
     let filter_item_rows = filter_items
         .iter()
         .map(|item| {
-            let is_active = filter_screen == FilterScreen::Main && current_filter == Some(item);
-            let is_inactive = current_filter == Some(item);
+            let is_selected_row = current_filter == Some(item);
+            let is_active = is_active_block && is_selected_row;
+            let is_inactive = !is_active && is_selected_row;
             let is_selected = match item {
                 &"method" => filter_screen == FilterScreen::Method,
                 &"source" => filter_screen == FilterScreen::Source,
@@ -1016,24 +1014,29 @@ pub fn render_filters(app: &mut Home, frame: &mut Frame, area: Rect) {
                 Line::from(vec![Span::raw(item.to_string())]).alignment(Alignment::Left),
             );
 
-            let row_style = if is_active {
-                RowStyle::Selected
+            let maybe_row_style = if is_active {
+                Some(RowStyle::Selected)
             } else if is_inactive {
-                RowStyle::Inactive
+                Some(RowStyle::Inactive)
             } else {
-                RowStyle::Default
+                None
             };
 
-            Row::new(vec![column_a, column_b]).style(get_row_style(row_style, &app.colors))
+            if let Some(row_style) = maybe_row_style {
+                Row::new(vec![column_a, column_b]).style(get_row_style(row_style, &app.colors))
+            } else {
+                Row::new(vec![column_a, column_b])
+            }
         })
         .collect::<Vec<_>>();
 
     let table = Table::new([filter_item_rows].concat())
         .block(Block::default().padding(Padding::new(0, 1, 0, 0)))
-        .style(get_text_style(
-            filter_screen == FilterScreen::Method,
-            &app.colors,
-        ))
+        .style(if filter_screen == FilterScreen::Main {
+            get_row_style(RowStyle::Active, &app.colors)
+        } else {
+            get_row_style(RowStyle::Default, &app.colors)
+        })
         .widths(&[Constraint::Length(3), Constraint::Percentage(100)])
         .column_spacing(3);
 
@@ -1191,7 +1194,7 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
     )])]);
 
     frame.render_widget(parent_block, area);
-    render_actionable_list(
+    render_selectable_list(
         &mut app.sort_sources,
         frame,
         layout[0],
@@ -1199,7 +1202,7 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
         app.active_block == ActiveBlock::Sort(SortScreen::Source),
     );
     frame.render_widget(divider, layout[1]);
-    render_actionable_list(
+    render_selectable_list(
         &mut app.sort_directions,
         frame,
         layout[2],
@@ -1220,7 +1223,11 @@ pub fn render_sort(app: &mut Home, frame: &mut Frame, area: Rect) {
 fn render_table(rows: Vec<Row>, frame: &mut Frame, area: Rect, colors: &Colors, active: bool) {
     let table = Table::new([rows].concat())
         .block(Block::default().padding(Padding::new(1, 0, 0, 0)))
-        .style(get_text_style(active, colors))
+        .style(if active {
+            get_row_style(RowStyle::Active, colors)
+        } else {
+            get_row_style(RowStyle::Default, colors)
+        })
         .widths(&[
             Constraint::Percentage(15),
             Constraint::Percentage(15),
@@ -1230,17 +1237,13 @@ fn render_table(rows: Vec<Row>, frame: &mut Frame, area: Rect, colors: &Colors, 
 
     frame.render_widget(table, area);
 }
-
-fn render_actionable_list(
+fn render_selectable_list(
     actionable_list: &mut ActionableList,
     frame: &mut Frame,
     area: Rect,
     colors: &Colors,
     active: bool,
 ) {
-    let actionable_item_style = Style::default().fg(colors.text.accent_2);
-    let active_item_style = get_row_style(RowStyle::Active, colors);
-    let default_item_style = get_row_style(RowStyle::Default, colors);
     let show_select_labels = actionable_list.show_select_labels;
 
     let items: Vec<ListItem> = actionable_list
@@ -1263,6 +1266,46 @@ fn render_actionable_list(
             spans.extend(vec![
                 Span::raw(format!("{:<15}", item.label)),
                 " ".into(),
+                Span::raw(item.value.clone().unwrap_or_default().to_string()),
+            ]);
+
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .style(if active {
+            get_row_style(RowStyle::Active, colors)
+        } else {
+            get_row_style(RowStyle::Default, colors)
+        })
+        .highlight_style(if active {
+            get_row_style(RowStyle::Selected, colors)
+        } else {
+            get_row_style(RowStyle::Inactive, colors)
+        });
+
+    frame.render_stateful_widget(list, area, &mut actionable_list.scroll_state)
+}
+
+fn render_actionable_list(
+    actionable_list: &mut ActionableList,
+    frame: &mut Frame,
+    area: Rect,
+    colors: &Colors,
+    active: bool,
+) {
+    let actionable_item_style = Style::default().fg(colors.text.accent_2);
+    let active_item_style = get_row_style(RowStyle::Active, colors);
+    let default_item_style = get_row_style(RowStyle::Default, colors);
+
+    let items: Vec<ListItem> = actionable_list
+        .items
+        .iter()
+        .map(|item| {
+            ListItem::new(Line::from(vec![
+                Span::raw(format!("{:<15}", item.label)),
+                " ".into(),
                 Span::styled(
                     item.value.clone().unwrap_or_default().to_string(),
                     if active && item.action.is_some() {
@@ -1273,9 +1316,7 @@ fn render_actionable_list(
                         default_item_style
                     },
                 ),
-            ]);
-
-            ListItem::new(Line::from(spans))
+            ]))
         })
         .collect();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,9 +129,9 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         })
         .collect::<Vec<&Trace>>();
 
-    items_as_vector.sort_by(|a, b| match &app.order {
+    items_as_vector.sort_by(|a, b| match &app.sort {
         TraceSort {
-            kind: SortSource::Duration,
+            source: SortSource::Duration,
             order: SortOrder::Ascending,
         } => a
             .http
@@ -141,7 +141,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             .unwrap_or(0)
             .cmp(&b.http.as_ref().unwrap().duration.unwrap_or(0)),
         TraceSort {
-            kind: SortSource::Duration,
+            source: SortSource::Duration,
             order: SortOrder::Descending,
         } => b
             .http
@@ -151,15 +151,15 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             .unwrap_or(0)
             .cmp(&a.http.as_ref().unwrap().duration.unwrap_or(0)),
         TraceSort {
-            kind: SortSource::Timestamp,
+            source: SortSource::Timestamp,
             order: SortOrder::Ascending,
         } => a.timestamp.cmp(&b.timestamp),
         TraceSort {
-            kind: SortSource::Timestamp,
+            source: SortSource::Timestamp,
             order: SortOrder::Descending,
         } => b.timestamp.cmp(&a.timestamp),
         TraceSort {
-            kind: SortSource::Status,
+            source: SortSource::Status,
             order: SortOrder::Descending,
         } => {
             let a_has = a.http.as_ref().unwrap().status.is_some();
@@ -182,7 +182,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             }
         }
         TraceSort {
-            kind: SortSource::Status,
+            source: SortSource::Status,
             order: SortOrder::Ascending,
         } => {
             let a_has = a.http.as_ref().unwrap().status.is_some();
@@ -205,7 +205,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             }
         }
         TraceSort {
-            kind: SortSource::Url,
+            source: SortSource::Url,
             order: SortOrder::Descending,
         } => {
             let url = &a.http.as_ref().unwrap().uri;
@@ -214,11 +214,11 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             url.cmp(&urlb)
         }
         TraceSort {
-            kind: SortSource::Url,
+            source: SortSource::Url,
             order: SortOrder::Ascending,
         } => a.timestamp.cmp(&b.timestamp),
         TraceSort {
-            kind: SortSource::Method,
+            source: SortSource::Method,
             order: SortOrder::Ascending,
         } => {
             let a_has = a.http.as_ref().unwrap().method.to_string();
@@ -227,7 +227,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             a_has.cmp(&b_has)
         }
         TraceSort {
-            kind: SortSource::Method,
+            source: SortSource::Method,
             order: SortOrder::Descending,
         } => {
             let a_has = a.http.as_ref().unwrap().method.to_string();
@@ -236,7 +236,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             b_has.cmp(&a_has)
         }
         TraceSort {
-            kind: SortSource::Source,
+            source: SortSource::Source,
             order: SortOrder::Ascending,
         } => {
             let a_has = &a.service_name;
@@ -245,7 +245,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             a_has.cmp(&b_has)
         }
         TraceSort {
-            kind: SortSource::Source,
+            source: SortSource::Source,
             order: SortOrder::Descending,
         } => {
             let a_has = &a.service_name;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,8 +2,8 @@ use core::str::FromStr;
 use http::Uri;
 use regex::Regex;
 
-use crate::app::{SortOrder, SortSource, TraceSort};
-use crate::components::home::{FilterSource, Home};
+use crate::app::{SortDirection, SortSource, TraceFilter, TraceSort};
+use crate::components::home::Home;
 use crate::services::websocket::Trace;
 
 // NOTE: [stackoverflow](https://stackoverflow.com/questions/38461429/how-can-i-truncate-a-string-to-have-at-most-n-characters)
@@ -83,9 +83,9 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             }
         })
         .filter(
-            |trace| match (app.get_filter_source(), trace.service_name.as_ref()) {
-                (FilterSource::All, _) => true,
-                (FilterSource::Applied(sources), Some(trace_source)) => {
+            |trace| match (app.get_filter(), trace.service_name.as_ref()) {
+                (TraceFilter::All, _) => true,
+                (TraceFilter::Applied(sources), Some(trace_source)) => {
                     sources.contains(trace_source)
                 }
                 _ => false,
@@ -132,7 +132,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
     items_as_vector.sort_by(|a, b| match &app.sort {
         TraceSort {
             source: SortSource::Duration,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => a
             .http
             .as_ref()
@@ -142,7 +142,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             .cmp(&b.http.as_ref().unwrap().duration.unwrap_or(0)),
         TraceSort {
             source: SortSource::Duration,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => b
             .http
             .as_ref()
@@ -152,15 +152,15 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
             .cmp(&a.http.as_ref().unwrap().duration.unwrap_or(0)),
         TraceSort {
             source: SortSource::Timestamp,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => a.timestamp.cmp(&b.timestamp),
         TraceSort {
             source: SortSource::Timestamp,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => b.timestamp.cmp(&a.timestamp),
         TraceSort {
             source: SortSource::Status,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => {
             let a_has = a.http.as_ref().unwrap().status.is_some();
             let b_has = b.http.as_ref().unwrap().status.is_some();
@@ -183,7 +183,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Status,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => {
             let a_has = a.http.as_ref().unwrap().status.is_some();
             let b_has = b.http.as_ref().unwrap().status.is_some();
@@ -206,7 +206,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Url,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => {
             let url = &a.http.as_ref().unwrap().uri;
             let urlb = &b.http.as_ref().unwrap().uri;
@@ -215,11 +215,11 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Url,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => a.timestamp.cmp(&b.timestamp),
         TraceSort {
             source: SortSource::Method,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => {
             let a_has = a.http.as_ref().unwrap().method.to_string();
             let b_has = b.http.as_ref().unwrap().method.to_string();
@@ -228,7 +228,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Method,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => {
             let a_has = a.http.as_ref().unwrap().method.to_string();
             let b_has = b.http.as_ref().unwrap().method.to_string();
@@ -237,7 +237,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Source,
-            order: SortOrder::Ascending,
+            direction: SortDirection::Ascending,
         } => {
             let a_has = &a.service_name;
             let b_has = &b.service_name;
@@ -246,7 +246,7 @@ pub fn get_rendered_items(app: &Home) -> Vec<&Trace> {
         }
         TraceSort {
             source: SortSource::Source,
-            order: SortOrder::Descending,
+            direction: SortDirection::Descending,
         } => {
             let a_has = &a.service_name;
             let b_has = &b.service_name;

--- a/src/wss.rs
+++ b/src/wss.rs
@@ -14,7 +14,7 @@ use tungstenite::connect;
 use tungstenite::handshake::server::{Callback, ErrorResponse, Request, Response};
 use url::Url;
 
-use crate::app::{Action,WebSocketInternalState};
+use crate::app::{Action, WebSocketInternalState};
 use crate::parser::parse_raw_trace;
 
 use tungstenite::Message;
@@ -236,9 +236,7 @@ pub async fn handle_connection(
 
     match number_of_connections - 1 {
         0 => {
-            let _ = action_sender.send(Action::SetWebsocketStatus(
-                WebSocketInternalState::Open,
-            ));
+            let _ = action_sender.send(Action::SetWebsocketStatus(WebSocketInternalState::Open));
 
             ()
         }
@@ -286,9 +284,8 @@ pub async fn handle_connection(
     if path != "/inner_client" {
         match number_of_connections - 1 {
             0 => {
-                let _ = action_sender.send(Action::SetWebsocketStatus(
-                    WebSocketInternalState::Open,
-                ));
+                let _ =
+                    action_sender.send(Action::SetWebsocketStatus(WebSocketInternalState::Open));
                 ()
             }
             v => {

--- a/src/wss.rs
+++ b/src/wss.rs
@@ -14,7 +14,7 @@ use tungstenite::connect;
 use tungstenite::handshake::server::{Callback, ErrorResponse, Request, Response};
 use url::Url;
 
-use crate::app::Action;
+use crate::app::{Action,WebSocketInternalState};
 use crate::parser::parse_raw_trace;
 
 use tungstenite::Message;
@@ -33,11 +33,7 @@ struct RequestPath {
 }
 
 impl Callback for &mut RequestPath {
-    fn on_request(
-        mut self,
-        request: &Request,
-        response: Response,
-    ) -> Result<Response, ErrorResponse> {
+    fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
         self.uri = request.uri().to_string();
 
         Ok(response)
@@ -241,14 +237,14 @@ pub async fn handle_connection(
     match number_of_connections - 1 {
         0 => {
             let _ = action_sender.send(Action::SetWebsocketStatus(
-                crate::components::home::WebSockerInternalState::Open,
+                WebSocketInternalState::Open,
             ));
 
             ()
         }
         v => {
             let _ = action_sender.send(Action::SetWebsocketStatus(
-                crate::components::home::WebSockerInternalState::Connected(v),
+                WebSocketInternalState::Connected(v),
             ));
 
             ()
@@ -291,13 +287,13 @@ pub async fn handle_connection(
         match number_of_connections - 1 {
             0 => {
                 let _ = action_sender.send(Action::SetWebsocketStatus(
-                    crate::components::home::WebSockerInternalState::Open,
+                    WebSocketInternalState::Open,
                 ));
                 ()
             }
             v => {
                 let _ = action_sender.send(Action::SetWebsocketStatus(
-                    crate::components::home::WebSockerInternalState::Connected(v),
+                    WebSocketInternalState::Connected(v),
                 ));
                 ()
             }


### PR DESCRIPTION
- Updates filter and sort selection to a 2-pane window and a single screen to more easily jump between selections
- Adds an `apply` action to right-hand side of filter and sort panel footers
- Previews filter and sort selections in the left-hand side of footer

TODO
[ ] - Clean up duplicated rendering logic for the `render_filters_source`, `render_filters_method`, and `render_filters_status` methods in `render.rs`

Screen recording:
![Screen Recording 2024-01-16 at 7 11 53 PM](https://github.com/FormidableLabs/envy-tui/assets/5840711/05b5e98a-65a1-4430-b13c-423146858b16)
